### PR TITLE
Feature/fluent validation

### DIFF
--- a/DevelopGitHub/GitHubExtension/GitHubExtension.Security.DAL/GitHubExtension.Security.DAL.csproj
+++ b/DevelopGitHub/GitHubExtension/GitHubExtension.Security.DAL/GitHubExtension.Security.DAL.csproj
@@ -62,8 +62,8 @@
       <HintPath>..\packages\Microsoft.Owin.Security.OAuth.3.0.1\lib\net45\Microsoft.Owin.Security.OAuth.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="Newtonsoft.Json, Version=6.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
-      <HintPath>..\packages\Newtonsoft.Json.6.0.4\lib\net45\Newtonsoft.Json.dll</HintPath>
+    <Reference Include="Newtonsoft.Json, Version=8.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
+      <HintPath>..\packages\Newtonsoft.Json.8.0.3\lib\net45\Newtonsoft.Json.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="Owin, Version=1.0.0.0, Culture=neutral, PublicKeyToken=f0ebd12fd5e55cc5, processorArchitecture=MSIL">

--- a/DevelopGitHub/GitHubExtension/GitHubExtension.Security.DAL/packages.config
+++ b/DevelopGitHub/GitHubExtension/GitHubExtension.Security.DAL/packages.config
@@ -9,7 +9,7 @@
   <package id="Microsoft.Owin" version="3.0.1" targetFramework="net45" />
   <package id="Microsoft.Owin.Security" version="3.0.1" targetFramework="net45" />
   <package id="Microsoft.Owin.Security.OAuth" version="3.0.1" targetFramework="net45" />
-  <package id="Newtonsoft.Json" version="6.0.4" targetFramework="net45" />
+  <package id="Newtonsoft.Json" version="8.0.3" targetFramework="net45" />
   <package id="Owin" version="1.0" targetFramework="net45" />
   <package id="SimpleInjector" version="3.1.2" targetFramework="net45" />
   <package id="SimpleInjector.Extensions.ExecutionContextScoping" version="3.1.2" targetFramework="net45" />

--- a/DevelopGitHub/GitHubExtension/GitHubExtension.Security.WebApi.Library/GitHubExtension.Security.WebApi.Library.csproj
+++ b/DevelopGitHub/GitHubExtension/GitHubExtension.Security.WebApi.Library/GitHubExtension.Security.WebApi.Library.csproj
@@ -38,6 +38,14 @@
       <HintPath>..\packages\EntityFramework.6.1.3\lib\net45\EntityFramework.SqlServer.dll</HintPath>
       <Private>True</Private>
     </Reference>
+    <Reference Include="FluentValidation, Version=6.2.1.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\FluentValidation.6.2.1.0\lib\Net45\FluentValidation.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="FluentValidation.WebApi, Version=6.2.1.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\FluentValidation.WebApi.6.2.1.0\lib\Net45\FluentValidation.WebApi.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
     <Reference Include="Microsoft.AspNet.Identity.Core, Version=2.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <HintPath>..\packages\Microsoft.AspNet.Identity.Core.2.2.1\lib\net45\Microsoft.AspNet.Identity.Core.dll</HintPath>
       <Private>True</Private>
@@ -189,6 +197,7 @@
     <Compile Include="Services\IAuthService.cs" />
     <Compile Include="Services\IGithubService.cs" />
     <Compile Include="SimpleInjectorConfiguration.cs" />
+    <Compile Include="Validators\ValidatorFactories\FluentValidatorFactory.cs" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\GitHubExtension.Models.CommunicationModels\GitHubExtension.Models.CommunicationModels.csproj">

--- a/DevelopGitHub/GitHubExtension/GitHubExtension.Security.WebApi.Library/GitHubExtension.Security.WebApi.Library.csproj
+++ b/DevelopGitHub/GitHubExtension/GitHubExtension.Security.WebApi.Library/GitHubExtension.Security.WebApi.Library.csproj
@@ -197,6 +197,7 @@
     <Compile Include="Services\IAuthService.cs" />
     <Compile Include="Services\IGithubService.cs" />
     <Compile Include="SimpleInjectorConfiguration.cs" />
+    <Compile Include="Validators\NullValidator.cs" />
     <Compile Include="Validators\ValidatorFactories\FluentValidatorFactory.cs" />
   </ItemGroup>
   <ItemGroup>

--- a/DevelopGitHub/GitHubExtension/GitHubExtension.Security.WebApi.Library/Package/WebApiLibraryPackage.cs
+++ b/DevelopGitHub/GitHubExtension/GitHubExtension.Security.WebApi.Library/Package/WebApiLibraryPackage.cs
@@ -14,10 +14,7 @@ namespace GitHubExtension.Security.WebApi.Library.Package
         {
             container.Register<IGithubService, GithubService>(Lifestyle.Singleton);
             container.Register<IAuthService, AuthService>(Lifestyle.Scoped);
-            var assemblies = AppDomain.CurrentDomain.GetAssemblies().ToList();
-            container.Register(typeof (IValidator<>), assemblies, Lifestyle.Singleton);
-            container.RegisterConditional(typeof (IValidator<>), typeof (NullValidator<>), Lifestyle.Singleton,
-                c => !c.Handled);
+            container.Register(typeof (IValidator<>), new[] {typeof (IValidator<>).Assembly}, Lifestyle.Singleton);
             container.Verify();
         }
     }

--- a/DevelopGitHub/GitHubExtension/GitHubExtension.Security.WebApi.Library/Package/WebApiLibraryPackage.cs
+++ b/DevelopGitHub/GitHubExtension/GitHubExtension.Security.WebApi.Library/Package/WebApiLibraryPackage.cs
@@ -2,6 +2,7 @@
 using System.Linq;
 using FluentValidation;
 using GitHubExtension.Security.WebApi.Library.Services;
+using GitHubExtension.Security.WebApi.Library.Validators;
 using SimpleInjector;
 using SimpleInjector.Packaging;
 
@@ -14,7 +15,9 @@ namespace GitHubExtension.Security.WebApi.Library.Package
             container.Register<IGithubService, GithubService>(Lifestyle.Singleton);
             container.Register<IAuthService, AuthService>(Lifestyle.Scoped);
             var assemblies = AppDomain.CurrentDomain.GetAssemblies().ToList();
-            container.Register(typeof(IValidator<>), assemblies);
+            container.Register(typeof (IValidator<>), assemblies, Lifestyle.Singleton);
+            container.RegisterConditional(typeof (IValidator<>), typeof (NullValidator<>), Lifestyle.Singleton,
+                c => !c.Handled);
             container.Verify();
         }
     }

--- a/DevelopGitHub/GitHubExtension/GitHubExtension.Security.WebApi.Library/Package/WebApiLibraryPackage.cs
+++ b/DevelopGitHub/GitHubExtension/GitHubExtension.Security.WebApi.Library/Package/WebApiLibraryPackage.cs
@@ -1,4 +1,7 @@
-﻿using GitHubExtension.Security.WebApi.Library.Services;
+﻿using System;
+using System.Linq;
+using FluentValidation;
+using GitHubExtension.Security.WebApi.Library.Services;
 using SimpleInjector;
 using SimpleInjector.Packaging;
 
@@ -10,6 +13,8 @@ namespace GitHubExtension.Security.WebApi.Library.Package
         {
             container.Register<IGithubService, GithubService>(Lifestyle.Singleton);
             container.Register<IAuthService, AuthService>(Lifestyle.Scoped);
+            var assemblies = AppDomain.CurrentDomain.GetAssemblies().ToList();
+            container.Register(typeof(IValidator<>), assemblies);
             container.Verify();
         }
     }

--- a/DevelopGitHub/GitHubExtension/GitHubExtension.Security.WebApi.Library/Package/WebApiLibraryPackage.cs
+++ b/DevelopGitHub/GitHubExtension/GitHubExtension.Security.WebApi.Library/Package/WebApiLibraryPackage.cs
@@ -1,4 +1,6 @@
-﻿using FluentValidation;
+﻿using System;
+using System.Linq;
+using FluentValidation;
 using GitHubExtension.Security.WebApi.Library.Services;
 using SimpleInjector;
 using SimpleInjector.Packaging;
@@ -11,8 +13,10 @@ namespace GitHubExtension.Security.WebApi.Library.Package
         {
             container.Register<IGithubService, GithubService>(Lifestyle.Singleton);
             container.Register<IAuthService, AuthService>(Lifestyle.Scoped);
-            container.Register(typeof (IValidator<>), new[] {typeof (IValidator<>).Assembly}, Lifestyle.Singleton);
+            var assemblies = AppDomain.CurrentDomain.GetAssemblies().ToList();
+            container.Register(typeof (IValidator<>), assemblies, Lifestyle.Singleton);
             container.Verify();
         }
     }
 }
+

--- a/DevelopGitHub/GitHubExtension/GitHubExtension.Security.WebApi.Library/Package/WebApiLibraryPackage.cs
+++ b/DevelopGitHub/GitHubExtension/GitHubExtension.Security.WebApi.Library/Package/WebApiLibraryPackage.cs
@@ -1,8 +1,5 @@
-﻿using System;
-using System.Linq;
-using FluentValidation;
+﻿using FluentValidation;
 using GitHubExtension.Security.WebApi.Library.Services;
-using GitHubExtension.Security.WebApi.Library.Validators;
 using SimpleInjector;
 using SimpleInjector.Packaging;
 

--- a/DevelopGitHub/GitHubExtension/GitHubExtension.Security.WebApi.Library/Validators/NullValidator.cs
+++ b/DevelopGitHub/GitHubExtension/GitHubExtension.Security.WebApi.Library/Validators/NullValidator.cs
@@ -1,0 +1,14 @@
+﻿using FluentValidation;
+using FluentValidation.Results;
+
+namespace GitHubExtension.Security.WebApi.Library.Validators
+{
+    sealed class NullValidator<T> : AbstractValidator<T>
+    {
+        public ValidationResult Validation(T instance)
+        {
+            return Validate(instance);
+        }
+    }
+}
+

--- a/DevelopGitHub/GitHubExtension/GitHubExtension.Security.WebApi.Library/Validators/ValidatorFactories/FluentValidatorFactory.cs
+++ b/DevelopGitHub/GitHubExtension/GitHubExtension.Security.WebApi.Library/Validators/ValidatorFactories/FluentValidatorFactory.cs
@@ -15,7 +15,7 @@ namespace GitHubExtension.Security.WebApi.Library.Validators.ValidatorFactories
 
         public override IValidator CreateInstance(Type validatorType)
         {
-            return ((IServiceProvider)_container).GetService(validatorType) as IValidator;
+            return _container.GetInstance(validatorType) as IValidator;
         }
     }
 }

--- a/DevelopGitHub/GitHubExtension/GitHubExtension.Security.WebApi.Library/Validators/ValidatorFactories/FluentValidatorFactory.cs
+++ b/DevelopGitHub/GitHubExtension/GitHubExtension.Security.WebApi.Library/Validators/ValidatorFactories/FluentValidatorFactory.cs
@@ -1,0 +1,21 @@
+﻿using System;
+using FluentValidation;
+using SimpleInjector;
+
+namespace GitHubExtension.Security.WebApi.Library.Validators.ValidatorFactories
+{
+    public class FluentValidatorFactory : ValidatorFactoryBase
+    {
+        private readonly Container _container;
+
+        public FluentValidatorFactory(Container container)
+        {
+            _container = container;
+        }
+
+        public override IValidator CreateInstance(Type validatorType)
+        {
+            return ((IServiceProvider)_container).GetService(validatorType) as IValidator;
+        }
+    }
+}

--- a/DevelopGitHub/GitHubExtension/GitHubExtension.Security.WebApi.Library/packages.config
+++ b/DevelopGitHub/GitHubExtension/GitHubExtension.Security.WebApi.Library/packages.config
@@ -17,7 +17,6 @@
   <package id="Microsoft.Owin.Security.Cookies" version="3.0.1" targetFramework="net45" />
   <package id="Microsoft.Owin.Security.OAuth" version="3.0.1" targetFramework="net45" />
   <package id="Microsoft.Web.Infrastructure" version="1.0.0.0" targetFramework="net45" />
-  <package id="Newtonsoft.Json" version="6.0.4" targetFramework="net45" />
   <package id="Newtonsoft.Json" version="8.0.3" targetFramework="net45" />
   <package id="NLog" version="4.2.3" targetFramework="net45" />
   <package id="Owin" version="1.0" targetFramework="net45" />

--- a/DevelopGitHub/GitHubExtension/GitHubExtension.Security.WebApi.Library/packages.config
+++ b/DevelopGitHub/GitHubExtension/GitHubExtension.Security.WebApi.Library/packages.config
@@ -1,6 +1,8 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
   <package id="EntityFramework" version="6.1.3" targetFramework="net45" />
+  <package id="FluentValidation" version="6.2.1.0" targetFramework="net45" />
+  <package id="FluentValidation.WebApi" version="6.2.1.0" targetFramework="net45" />
   <package id="Microsoft.AspNet.Identity.Core" version="2.2.1" targetFramework="net45" />
   <package id="Microsoft.AspNet.Identity.EntityFramework" version="2.2.1" targetFramework="net45" />
   <package id="Microsoft.AspNet.Identity.Owin" version="2.2.1" targetFramework="net45" />

--- a/DevelopGitHub/GitHubExtension/GitHubExtension.Security.WebApi/GitHubExtension.Security.WebApi.csproj
+++ b/DevelopGitHub/GitHubExtension/GitHubExtension.Security.WebApi/GitHubExtension.Security.WebApi.csproj
@@ -46,6 +46,14 @@
       <HintPath>..\packages\EntityFramework.6.1.3\lib\net45\EntityFramework.SqlServer.dll</HintPath>
       <Private>True</Private>
     </Reference>
+    <Reference Include="FluentValidation, Version=6.2.1.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\FluentValidation.6.2.1.0\lib\Net45\FluentValidation.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="FluentValidation.WebApi, Version=6.2.1.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\FluentValidation.WebApi.6.2.1.0\lib\Net45\FluentValidation.WebApi.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
     <Reference Include="Microsoft.AspNet.Identity.Core, Version=2.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <HintPath>..\packages\Microsoft.AspNet.Identity.Core.2.2.1\lib\net45\Microsoft.AspNet.Identity.Core.dll</HintPath>
       <Private>True</Private>

--- a/DevelopGitHub/GitHubExtension/GitHubExtension.Security.WebApi/Startup.cs
+++ b/DevelopGitHub/GitHubExtension/GitHubExtension.Security.WebApi/Startup.cs
@@ -3,12 +3,14 @@ using System.Data.Entity;
 using System.Linq;
 using System.Net.Http.Formatting;
 using System.Web.Http;
+using FluentValidation.WebApi;
 using GitHubExtension.Security.DAL.Context;
 using GitHubExtension.Security.DAL.Infrastructure;
 using GitHubExtension.Security.StorageModels.Identity;
 using GitHubExtension.Security.WebApi.Library;
 using GitHubExtension.Security.WebApi.Library.ActionFilters;
 using GitHubExtension.Security.WebApi.Library.Provider;
+using GitHubExtension.Security.WebApi.Library.Validators.ValidatorFactories;
 using Microsoft.AspNet.Identity;
 using Microsoft.AspNet.Identity.Owin;
 using Microsoft.Owin;
@@ -49,6 +51,10 @@ namespace GitHubExtension.Security.WebApi
             app.CreatePerOwinContext(() => container.GetInstance<SecurityContext>());
 
             app.CreatePerOwinContext<ApplicationUserManager>(ApplicationUserManager.Create);
+
+            FluentValidationModelValidatorProvider
+                .Configure(config,
+                    provider => provider.ValidatorFactory = new FluentValidatorFactory(container));
 
             app.UseWebApi(config);
 

--- a/DevelopGitHub/GitHubExtension/GitHubExtension.Security.WebApi/packages.config
+++ b/DevelopGitHub/GitHubExtension/GitHubExtension.Security.WebApi/packages.config
@@ -2,6 +2,8 @@
 <packages>
   <package id="bootstrap" version="3.3.6" targetFramework="net45" />
   <package id="EntityFramework" version="6.1.3" targetFramework="net45" />
+  <package id="FluentValidation" version="6.2.1.0" targetFramework="net45" />
+  <package id="FluentValidation.WebApi" version="6.2.1.0" targetFramework="net45" />
   <package id="jQuery" version="1.9.1" targetFramework="net45" />
   <package id="Microsoft.AspNet.Identity.Core" version="2.2.1" targetFramework="net45" />
   <package id="Microsoft.AspNet.Identity.EntityFramework" version="2.2.1" targetFramework="net45" />


### PR DESCRIPTION
Add Fluent Validation
<a href='#crh-start'></a><a href='#crh-data-%7B%22processed%22%3A%20%5B%22https%3A//github.com/ITsvetkoFF/Kv-013/pull/12%23discussion_r58039347%22%2C%20%22https%3A//github.com/ITsvetkoFF/Kv-013/pull/12%23discussion_r58039400%22%2C%20%22https%3A//github.com/ITsvetkoFF/Kv-013/pull/12%23discussion_r58045740%22%2C%20%22https%3A//github.com/ITsvetkoFF/Kv-013/pull/12%23discussion_r58048772%22%2C%20%22https%3A//github.com/ITsvetkoFF/Kv-013/pull/12%23discussion_r58099574%22%2C%20%22https%3A//github.com/ITsvetkoFF/Kv-013/pull/12%23discussion_r58099673%22%2C%20%22https%3A//github.com/ITsvetkoFF/Kv-013/pull/12%23discussion_r58101819%22%2C%20%22https%3A//github.com/ITsvetkoFF/Kv-013/pull/12%23discussion_r58101886%22%2C%20%22https%3A//github.com/ITsvetkoFF/Kv-013/pull/12%23discussion_r58102922%22%2C%20%22https%3A//github.com/ITsvetkoFF/Kv-013/pull/12%23discussion_r58103631%22%2C%20%22https%3A//github.com/ITsvetkoFF/Kv-013/pull/12%23discussion_r58109974%22%2C%20%22https%3A//github.com/ITsvetkoFF/Kv-013/pull/12%23discussion_r58211729%22%5D%2C%20%22comments%22%3A%20%7B%22Pull%205eff40279a7a0f0c5996b92b9502730196685047%20DevelopGitHub/GitHubExtension/GitHubExtension.Security.WebApi.Library/Validators/ValidatorFactories/FluentValidatorFactory.cs%2018%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/ITsvetkoFF/Kv-013/pull/12%23discussion_r58039347%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22Can%20you%20get%20a%20validator%20instance%20without%20casting%20to%20IServiceProvider%3F%22%2C%20%22created_at%22%3A%20%222016-03-31T11%3A37%3A54Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6068068%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/TerraVenil%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20DevelopGitHub/GitHubExtension/GitHubExtension.Security.WebApi.Library/Validators/ValidatorFactories/FluentValidatorFactory.cs%3AL1-22%22%7D%2C%20%22Pull%20e42b5a73ea2394fef4fc4d0009c3ce7e5632c11f%20DevelopGitHub/GitHubExtension/GitHubExtension.Security.WebApi.Library/Validators/NullValidator.cs%206%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/ITsvetkoFF/Kv-013/pull/12%23discussion_r58099673%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22What%20the%20purpose%20of%20this%20validator%3F%22%2C%20%22created_at%22%3A%20%222016-03-31T18%3A04%3A03Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6068068%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/TerraVenil%22%7D%7D%2C%20%7B%22body%22%3A%20%22When%20I%20removed%20IServiceProvider%20I%20faced%20with%20problem%20that%20entity%20without%20own%20validators%20generate%20runtime%20error.%20So%20we%20need%20implement%20NullValidator%20for%20handling%20this%20situation%5Cr%5Cnhttps%3A//simpleinjector.readthedocs.org/en/latest/advanced.html%23registration-of-open-generic-types%22%2C%20%22created_at%22%3A%20%222016-03-31T18%3A17%3A00Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/15123688%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/craHUNzyTER%22%7D%7D%2C%20%7B%22body%22%3A%20%22As%20I%20understand%20it%27s%20something%20like%20template%20for%20those%20entities%20which%20are%20not%20registered%20with%20IValidator%20interface%20correct%3F%20And%20the%20NullValidator%20will%20be%20skipped.%20But%20you%20can%20forgot%20implement%20validator%20for%20entity%20due%20to%20behind%20the%20scene%20you%20already%20registered%20all%20possible%20entities.%20Do%20you%20this%20this%20is%20a%20good%20solution%3F%22%2C%20%22created_at%22%3A%20%222016-03-31T18%3A27%3A14Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6068068%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/TerraVenil%22%7D%7D%2C%20%7B%22body%22%3A%20%22I%20think%20there%20are%20two%20ways%20and%20our%20team%20should%20choose%20one.%5Cr%5Cn1.%5CtWhen%20someone%20creates%20entity%20he%20must%20immediately%20create%20validator%20for%20this%20if%20it%20needed.%5Cr%5Cn2.%5CtWhen%20someone%20creates%20entity%20that%20don%5Cu2019t%20need%20validator%20he%20must%20don%5Cu2019t%20forget%20to%20write%20line%20of%20code%5Cr%5Cncontainer.Register%3CIValidate%3CEntity%3E%2C%20NullValidator%3CEntity%3E%3E%28%29%3B%5Cr%5Cn%5Cr%5CnNow%20I%20understand%20that%202nd%20approach%20is%20better%2C%20cause%20we%20can%20find%20runtime%20error%20with%20tests.%20When%20in%201st%20approach%20we%20can%20validate%20not-valid%20entity%20if%20someone%20will%20forget%20to%20create%20validator.%5Cr%5CnThanks.%22%2C%20%22created_at%22%3A%20%222016-03-31T19%3A06%3A25Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/15123688%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/craHUNzyTER%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20DevelopGitHub/GitHubExtension/GitHubExtension.Security.WebApi.Library/Validators/NullValidator.cs%3AL1-15%22%7D%2C%20%22Pull%20e42b5a73ea2394fef4fc4d0009c3ce7e5632c11f%20DevelopGitHub/GitHubExtension/GitHubExtension.Security.WebApi.Library/Package/WebApiLibraryPackage.cs%2016%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/ITsvetkoFF/Kv-013/pull/12%23discussion_r58099574%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22Can%20you%20explain%20this%20strange%20registration%3F%22%2C%20%22created_at%22%3A%20%222016-03-31T18%3A03%3A24Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6068068%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/TerraVenil%22%7D%7D%2C%20%7B%22body%22%3A%20%22Yes.%20FIrst%20we%20search%20through%20our%20assembly.%20And%20then%20register%20all%20validators%20that%20implement%20IValidator%3C%3E.%5Cr%5CnThe%20last%20line%20need%20to%20register%20NullValidator%20for%20all%20entities%20that%20haven%27t%20own%20validators.%20In%20other%20case%20we%20will%20have%20runtime%20error%20when%20try%20to%20work%20with%20such%20entity.%5Cr%5Cn%5Cr%5CnI%20think%20I%20should%20replace%20first%202%20lines%20on%20this%20%5Cr%5Cnvar%20assemblies%20%3D%20new%5B%5D%20%7B%20typeof%28IValidator%3C%3E%29.Assembly%20%7D%3B%5Cr%5Cncontainer.RegisterCollection%28typeof%28IValidator%3C%3E%29%2C%20assemblies%29%3B%5Cr%5Cnaccording%20to%20the%20best%20practice%20in%20SI%20docs.%5Cr%5Cn%5Cr%5Cnhttps%3A//simpleinjector.readthedocs.org/en/latest/advanced.html%23batch-registration%22%2C%20%22created_at%22%3A%20%222016-03-31T18%3A16%3A37Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/15123688%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/craHUNzyTER%22%7D%7D%2C%20%7B%22body%22%3A%20%22Something%20like%20that%2C%20the%20idea%20is%20that%20you%20should%20not%20iterate%20though%20the%20all%20assemblies%20in%20domain%20but%20only%20in%20those%20which%20contains%20implementation%20IValidator%20interface.%22%2C%20%22created_at%22%3A%20%222016-03-31T18%3A23%3A02Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6068068%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/TerraVenil%22%7D%7D%2C%20%7B%22body%22%3A%20%22I%20restored%20previous%20way%20of%20registration%2C%20because%20%60new%5B%5D%20%7B%20typeof%28IValidator%3C%3E%29.Assembly%20%7D%3B%60%20return%20only%20FluentValidation%20library%2C%20that%20doesn%27t%20include%20validators%2C%20that%20we%20have%20created.%22%2C%20%22created_at%22%3A%20%222016-04-01T14%3A18%3A22Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/15123688%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/craHUNzyTER%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20DevelopGitHub/GitHubExtension/GitHubExtension.Security.WebApi.Library/Package/WebApiLibraryPackage.cs%3AL14-24%22%7D%2C%20%22Pull%205eff40279a7a0f0c5996b92b9502730196685047%20DevelopGitHub/GitHubExtension/GitHubExtension.Security.WebApi/Startup.cs%2021%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/ITsvetkoFF/Kv-013/pull/12%23discussion_r58039400%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22Is%20it%20possible%20configure%20factory%20without%20lambda%20expression%3F%22%2C%20%22created_at%22%3A%20%222016-03-31T11%3A38%3A28Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6068068%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/TerraVenil%22%7D%7D%2C%20%7B%22body%22%3A%20%22I%20don%27t%20know%20how%20to%20do%20this%20in%20simple%20way%20yet.%5Cr%5CnThere%20is%20an%20example%20in%20FluentValidation%20wiki%20for%20MVC%20with%20lambda.%20https%3A//github.com/JeremySkinner/FluentValidation/wiki/h.-MVC%5Cr%5Cn%5Cr%5CnFluentValidationModelValidatorProvider.Configure%28provider%20%3D%3E%20%7B%5Cr%5Cn%20%20provider.ValidatorFactory%20%3D%20new%20MyCustomValidatorFactory%28%29%3B%5Cr%5Cn%7D%29%3B%5Cr%5Cn%5Cr%5CnBut%20I%20will%20try%20to%20find%20another%20way.%22%2C%20%22created_at%22%3A%20%222016-03-31T12%3A37%3A31Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/15123688%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/craHUNzyTER%22%7D%7D%2C%20%7B%22body%22%3A%20%22Ok%2C%20but%20don%27t%20spent%20too%20much%20time.%22%2C%20%22created_at%22%3A%20%222016-03-31T13%3A00%3A52Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6068068%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/TerraVenil%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20DevelopGitHub/GitHubExtension/GitHubExtension.Security.WebApi/Startup.cs%3AL52-62%22%7D%7D%7D'></a>
<a href='https://www.codereviewhub.com/'><img src='http://www.codereviewhub.com/site/github-bar.png' height=40></a>
- [ ] <a href='#crh-comment-Pull 5eff40279a7a0f0c5996b92b9502730196685047 DevelopGitHub/GitHubExtension/GitHubExtension.Security.WebApi.Library/Validators/ValidatorFactories/FluentValidatorFactory.cs 18'></a> <img src='http://www.codereviewhub.com/site/github-remaining.png' height=16 width=60>&nbsp;<b><a href='https://github.com/ITsvetkoFF/Kv-013/pull/12#discussion_r58039347'>File: DevelopGitHub/GitHubExtension/GitHubExtension.Security.WebApi.Library/Validators/ValidatorFactories/FluentValidatorFactory.cs:L1-22</a></b>
- <a href='https://github.com/TerraVenil'><img border=0 src='https://avatars.githubusercontent.com/u/6068068?v=3' height=16 width=16'></a> Can you get a validator instance without casting to IServiceProvider?
- [ ] <a href='#crh-comment-Pull 5eff40279a7a0f0c5996b92b9502730196685047 DevelopGitHub/GitHubExtension/GitHubExtension.Security.WebApi/Startup.cs 21'></a> <img src='http://www.codereviewhub.com/site/github-remaining.png' height=16 width=60>&nbsp;<b><a href='https://github.com/ITsvetkoFF/Kv-013/pull/12#discussion_r58039400'>File: DevelopGitHub/GitHubExtension/GitHubExtension.Security.WebApi/Startup.cs:L52-62</a></b>
- <a href='https://github.com/TerraVenil'><img border=0 src='https://avatars.githubusercontent.com/u/6068068?v=3' height=16 width=16'></a> Is it possible configure factory without lambda expression?
- <a href='https://github.com/craHUNzyTER'><img border=0 src='https://avatars.githubusercontent.com/u/15123688?v=3' height=16 width=16'></a> I don't know how to do this in simple way yet.
  There is an example in FluentValidation wiki for MVC with lambda. https://github.com/JeremySkinner/FluentValidation/wiki/h.-MVC
  FluentValidationModelValidatorProvider.Configure(provider => {
  provider.ValidatorFactory = new MyCustomValidatorFactory();
  });
  But I will try to find another way.
- <a href='https://github.com/TerraVenil'><img border=0 src='https://avatars.githubusercontent.com/u/6068068?v=3' height=16 width=16'></a> Ok, but don't spent too much time.
- [ ] <a href='#crh-comment-Pull e42b5a73ea2394fef4fc4d0009c3ce7e5632c11f DevelopGitHub/GitHubExtension/GitHubExtension.Security.WebApi.Library/Package/WebApiLibraryPackage.cs 16'></a> <img src='http://www.codereviewhub.com/site/github-remaining.png' height=16 width=60>&nbsp;<b><a href='https://github.com/ITsvetkoFF/Kv-013/pull/12#discussion_r58099574'>File: DevelopGitHub/GitHubExtension/GitHubExtension.Security.WebApi.Library/Package/WebApiLibraryPackage.cs:L14-24</a></b>
- <a href='https://github.com/TerraVenil'><img border=0 src='https://avatars.githubusercontent.com/u/6068068?v=3' height=16 width=16'></a> Can you explain this strange registration?
- <a href='https://github.com/craHUNzyTER'><img border=0 src='https://avatars.githubusercontent.com/u/15123688?v=3' height=16 width=16'></a> Yes. FIrst we search through our assembly. And then register all validators that implement IValidator<>.
  The last line need to register NullValidator for all entities that haven't own validators. In other case we will have runtime error when try to work with such entity.
  I think I should replace first 2 lines on this
  var assemblies = new[] { typeof(IValidator<>).Assembly };
  container.RegisterCollection(typeof(IValidator<>), assemblies);
  according to the best practice in SI docs.
  https://simpleinjector.readthedocs.org/en/latest/advanced.html#batch-registration
- <a href='https://github.com/TerraVenil'><img border=0 src='https://avatars.githubusercontent.com/u/6068068?v=3' height=16 width=16'></a> Something like that, the idea is that you should not iterate though the all assemblies in domain but only in those which contains implementation IValidator interface.
- <a href='https://github.com/craHUNzyTER'><img border=0 src='https://avatars.githubusercontent.com/u/15123688?v=3' height=16 width=16'></a> I restored previous way of registration, because `new[] { typeof(IValidator<>).Assembly };` return only FluentValidation library, that doesn't include validators, that we have created.
- [ ] <a href='#crh-comment-Pull e42b5a73ea2394fef4fc4d0009c3ce7e5632c11f DevelopGitHub/GitHubExtension/GitHubExtension.Security.WebApi.Library/Validators/NullValidator.cs 6'></a> <img src='http://www.codereviewhub.com/site/github-remaining.png' height=16 width=60>&nbsp;<b><a href='https://github.com/ITsvetkoFF/Kv-013/pull/12#discussion_r58099673'>File: DevelopGitHub/GitHubExtension/GitHubExtension.Security.WebApi.Library/Validators/NullValidator.cs:L1-15</a></b>
- <a href='https://github.com/TerraVenil'><img border=0 src='https://avatars.githubusercontent.com/u/6068068?v=3' height=16 width=16'></a> What the purpose of this validator?
- <a href='https://github.com/craHUNzyTER'><img border=0 src='https://avatars.githubusercontent.com/u/15123688?v=3' height=16 width=16'></a> When I removed IServiceProvider I faced with problem that entity without own validators generate runtime error. So we need implement NullValidator for handling this situation
  https://simpleinjector.readthedocs.org/en/latest/advanced.html#registration-of-open-generic-types
- <a href='https://github.com/TerraVenil'><img border=0 src='https://avatars.githubusercontent.com/u/6068068?v=3' height=16 width=16'></a> As I understand it's something like template for those entities which are not registered with IValidator interface correct? And the NullValidator will be skipped. But you can forgot implement validator for entity due to behind the scene you already registered all possible entities. Do you this this is a good solution?
- <a href='https://github.com/craHUNzyTER'><img border=0 src='https://avatars.githubusercontent.com/u/15123688?v=3' height=16 width=16'></a> I think there are two ways and our team should choose one.
-  When someone creates entity he must immediately create validator for this if it needed.
-  When someone creates entity that don’t need validator he must don’t forget to write line of code
  container.Register<IValidate<Entity>, NullValidator<Entity>>();
  Now I understand that 2nd approach is better, cause we can find runtime error with tests. When in 1st approach we can validate not-valid entity if someone will forget to create validator.
  Thanks.

<a href='https://www.codereviewhub.com/ITsvetkoFF/Kv-013/pull/12?mark_as_completed=1'><img src='http://www.codereviewhub.com/site/github-mark-as-completed.png' height=26></a>&nbsp;<a href='https://www.codereviewhub.com/ITsvetkoFF/Kv-013/pull/12?approve=1'><img src='http://www.codereviewhub.com/site/github-approve.png' height=26></a>&nbsp;<a href='https://github.com/ITsvetkoFF/Kv-013/pull/12'><img src='http://www.codereviewhub.com/site/github-refresh.png' height=26></a>
<a href='#crh-end'></a>
