### PR TITLE
Fix role assignments on backend

### DIFF
--- a/DevelopGitHub/GitHubExtension/GitHubExtension.EntryPoint/index.html
+++ b/DevelopGitHub/GitHubExtension/GitHubExtension.EntryPoint/index.html
@@ -96,7 +96,7 @@
     <script src="./FrontEnd/src/client/app/roles/roles.controller.js"></script>
     <script src="./FrontEnd/src/client/app/roles/roles.route.js"></script>
     <script src="./FrontEnd/src/client/app/user/user.service.js"></script>
-    <script src="./FrontEnd/src/client/app/userpreferences/file.directive.js"></script>
+    <script src="./FrontEnd/src/client/app/userpreferences/ge-custom-on-change.directive.js"></script>
     <script src="./FrontEnd/src/client/app/userpreferences/user-data.factory.js"></script>
     <script src="./FrontEnd/src/client/app/userpreferences/userpreferences.controller.js"></script>
     <script src="./FrontEnd/src/client/app/userpreferences/userpreferences.route.js"></script>

--- a/DevelopGitHub/GitHubExtension/GitHubExtension.Security.Tests/GitHubExtension.Security.Tests.csproj
+++ b/DevelopGitHub/GitHubExtension/GitHubExtension.Security.Tests/GitHubExtension.Security.Tests.csproj
@@ -114,7 +114,7 @@
     <Compile Include="Mocks\MockForDbSet.cs" />
     <Compile Include="Mocks\MockForEnumerableQuery.cs" />
     <Compile Include="TestExtensions\UserToUserReturnModelTests.cs" />
-    <Compile Include="TestForControllers\AccountControllerAssignRolesToUserTests.cs" />
+    <Compile Include="TestForControllers\RepositoryControllerAssignRolesToUserTests.cs" />
     <Compile Include="TestForControllers\AccountControllerGetUserByIdTests.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="TestForControllers\AccountControllerGetUserByNameTests.cs" />

--- a/DevelopGitHub/GitHubExtension/GitHubExtension.Security.Tests/TestForControllers/RepositoryControllerAssignRolesToUserTests.cs
+++ b/DevelopGitHub/GitHubExtension/GitHubExtension.Security.Tests/TestForControllers/RepositoryControllerAssignRolesToUserTests.cs
@@ -18,7 +18,7 @@ using GitHubExtension.Security.Tests.Extensions;
 
 namespace GitHubExtension.Security.Tests.TestForControllers
 {
-    public class AccountControllerAssignRolesToUserTests
+    public class RepositoryControllerAssignRolesToUserTests
     {
         private const string roleIndex = "role";
         private const string expectedErrorForInvalidRole = "Roles '{0}' does not exists in the system";
@@ -114,7 +114,7 @@ namespace GitHubExtension.Security.Tests.TestForControllers
         public void NotFoundUserTest(List<User> users, int gitHubId, int repoId, string roleToAssign)
         {
             //Arrange
-            AccountController controller = new AccountController(Substitute.For<IGithubService>(),
+            RepositoryController controller = new RepositoryController(Substitute.For<IGithubService>(),
                 Substitute.For<ISecurityContext>(), MockForUsers(users));
 
             //Act
@@ -130,7 +130,7 @@ namespace GitHubExtension.Security.Tests.TestForControllers
         public void InvalidRoleTest(List<User> users, IEnumerable<SecurityRole> roles, int gitHubId, int repoId, string roleToAssign)
         {
             //Arrenge
-            AccountController controller = new AccountController(Substitute.For<IGithubService>(), MockForContext(roles), MockForUsers(users));
+            RepositoryController controller = new RepositoryController(Substitute.For<IGithubService>(), MockForContext(roles), MockForUsers(users));
 
             //Act
             Task<IHttpActionResult> response = controller.AssignRolesToUser(repoId, gitHubId, roleToAssign);
@@ -145,7 +145,7 @@ namespace GitHubExtension.Security.Tests.TestForControllers
         public void ErrorMessageForInvalidRoleTest(List<User> users, IEnumerable<SecurityRole> roles, int gitHubId, int repoId, string roleToAssign)
         {
             //Arrange
-            AccountController controller = new AccountController(Substitute.For<IGithubService>(), MockForContext(roles), MockForUsers(users));
+            RepositoryController controller = new RepositoryController(Substitute.For<IGithubService>(), MockForContext(roles), MockForUsers(users));
 
             //Act
             Task<IHttpActionResult> response = controller.AssignRolesToUser(repoId, gitHubId, roleToAssign);
@@ -162,7 +162,7 @@ namespace GitHubExtension.Security.Tests.TestForControllers
         {
             //Arrange
             users.Add(userToUpdate);
-            AccountController controller = new AccountController(Substitute.For<IGithubService>(), MockForContext(roles), MockForAddingClaim(users, userToUpdate));
+            RepositoryController controller = new RepositoryController(Substitute.For<IGithubService>(), MockForContext(roles), MockForAddingClaim(users, userToUpdate));
 
             //Act
             Task<IHttpActionResult> response = controller.AssignRolesToUser(repoId, gitHubId, roleToAssign);

--- a/DevelopGitHub/GitHubExtension/GitHubExtension.Security.Tests/TestRoutes/AccountTestRoutes.cs
+++ b/DevelopGitHub/GitHubExtension/GitHubExtension.Security.Tests/TestRoutes/AccountTestRoutes.cs
@@ -36,12 +36,12 @@ namespace GitHubExtension.Security.Tests.TestRoutes
         }
 
         [Fact]
-        public void AccountAssignRolesToUserTest()
+        public void RepositoryAssignRolesToUserTest()
         {
             url = url.ForAccountAssignRolesToUser();
 
             config.ShouldMap(url)
-                .To<AccountController>(new HttpMethod("PATCH"),
+                .To<RepositoryController>(new HttpMethod("PATCH"),
                 x => x.AssignRolesToUser(5, 6, null));
         }
 

--- a/DevelopGitHub/GitHubExtension/GitHubExtension.Security.WebApi/Controllers/AccountController.cs
+++ b/DevelopGitHub/GitHubExtension/GitHubExtension.Security.WebApi/Controllers/AccountController.cs
@@ -65,59 +65,6 @@ namespace GitHubExtension.Security.WebApi.Controllers
             return NotFound();
         }
 
-        [HttpPatch]
-        [AllowAnonymous]
-        [Route(RouteConstants.AssignRolesToUser)]
-        public async Task<IHttpActionResult> AssignRolesToUser([FromUri] int repoId, [FromUri] int gitHubId,
-            [FromBody] string roleToAssign)
-        {
-            User appUser = await _userManager.Users.FirstOrDefaultAsync(u => u.ProviderId == gitHubId);
-            if (appUser == null)
-                return NotFound();
-
-            var repositoryRole = appUser.UserRepositoryRoles.FirstOrDefault(r => r.RepositoryId == repoId);
-
-            if (repositoryRole != null)
-                appUser.UserRepositoryRoles.Remove(repositoryRole);
-
-            var role = await _securityContext.SecurityRoles.FirstOrDefaultAsync(r => r.Name == roleToAssign);
-            if (role == null)
-            {
-                ModelState.AddModelError("role",
-                    string.Format("Roles '{0}' does not exists in the system", roleToAssign));
-                return BadRequest(ModelState);
-            }
-
-            appUser.UserRepositoryRoles.Add(new UserRepositoryRole()
-            {
-                RepositoryId = repoId,
-                SecurityRoleId = role.Id
-            });
-
-            IdentityResult updateResult = await _userManager.UpdateAsync(appUser);
-
-            if (!updateResult.Succeeded)
-            {
-                ModelState.AddModelError("Role", "Failed to remove user roles");
-                return BadRequest(ModelState);
-            }
-
-            var claimsIdentity =
-                await appUser.GenerateUserIdentityAsync(_userManager, DefaultAuthenticationTypes.ApplicationCookie);
-            var existingClaim = claimsIdentity.Claims.FirstOrDefault(c => c.Value == repoId.ToString());
-            if (existingClaim != null)
-                _userManager.RemoveClaim(appUser.Id, existingClaim);
-            var addClaimResult =
-                await _userManager.AddClaimAsync(appUser.Id, new Claim(roleToAssign, repoId.ToString()));
-
-            if (!addClaimResult.Succeeded)
-            {
-                ModelState.AddModelError("Role", "Failed to remove user roles");
-                return BadRequest(ModelState);
-            }
-
-            return Ok();
-        }
 
         [HttpGet]
         [OverrideAuthentication]


### PR DESCRIPTION
Hot fix to adding roles, route to role assignments was changed after move AssignRolesToUser to RepositoryController.
<a href='#crh-start'></a><a href='#crh-data-%7B%7D'></a>
<a href='https://www.codereviewhub.com/'><img src='http://www.codereviewhub.com/site/github-bar.png' height=40></a>
<a href='https://www.codereviewhub.com/ITsvetkoFF/Kv-013/pull/82?approve=1'><img src='http://www.codereviewhub.com/site/github-approve.png' height=26></a>&nbsp;<a href='https://github.com/ITsvetkoFF/Kv-013/pull/82'><img src='http://www.codereviewhub.com/site/github-refresh.png' height=26></a>
<a href='#crh-end'></a>
