### PR TITLE
Feature/tests private notes

### DIFF
--- a/DevelopGitHub/GitHubExtension/.nuget/packages.config
+++ b/DevelopGitHub/GitHubExtension/.nuget/packages.config
@@ -1,0 +1,4 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<packages>
+  <package id="xunit.runners" version="2.0.0" />
+</packages>

--- a/DevelopGitHub/GitHubExtension/GitHubExtension.EntryPoint/Startup.cs
+++ b/DevelopGitHub/GitHubExtension/GitHubExtension.EntryPoint/Startup.cs
@@ -60,6 +60,23 @@ namespace GitHubExtension.EntryPoint
             Database.SetInitializer(new MigrateDatabaseToLatestVersion<SecurityContext, Configuration>());
         }
 
+        public HttpConfiguration ConfigureWebApi()
+        {
+            HttpConfiguration config = new HttpConfiguration();
+
+            config.MapHttpAttributeRoutes();
+
+            var jsonFormatter = config.Formatters.OfType<JsonMediaTypeFormatter>().First();
+            jsonFormatter.SerializerSettings.ContractResolver = new CamelCasePropertyNamesContractResolver();
+            jsonFormatter.SerializerSettings.PreserveReferencesHandling =
+                Newtonsoft.Json.PreserveReferencesHandling.Objects;
+            config.Formatters.Remove(config.Formatters.XmlFormatter);
+            config.Filters.Add(new LoggingFilterAttribute());
+            config.Filters.Add(new ModelIsNullFilterAttribute());
+
+            return config;
+        }
+
         void ConfigureCookies(IAppBuilder app)
         {
             app.UseCookieAuthentication(
@@ -95,23 +112,6 @@ namespace GitHubExtension.EntryPoint
 
             GitHubAuthOptions.Scope.Add("user,repo");
             app.UseGitHubAuthentication(GitHubAuthOptions);
-        }
-
-        public HttpConfiguration ConfigureWebApi()
-        {
-            HttpConfiguration config = new HttpConfiguration();
-
-            config.MapHttpAttributeRoutes();
-
-            var jsonFormatter = config.Formatters.OfType<JsonMediaTypeFormatter>().First();
-            jsonFormatter.SerializerSettings.ContractResolver = new CamelCasePropertyNamesContractResolver();
-            jsonFormatter.SerializerSettings.PreserveReferencesHandling =
-                Newtonsoft.Json.PreserveReferencesHandling.Objects;
-            config.Formatters.Remove(config.Formatters.XmlFormatter);
-            config.Filters.Add(new LoggingFilterAttribute());
-            config.Filters.Add(new ModelIsNullFilterAttribute());
-
-            return config;
         }
     }
 }

--- a/DevelopGitHub/GitHubExtension/GitHubExtension.EntryPoint/Startup.cs
+++ b/DevelopGitHub/GitHubExtension/GitHubExtension.EntryPoint/Startup.cs
@@ -97,7 +97,7 @@ namespace GitHubExtension.EntryPoint
             app.UseGitHubAuthentication(GitHubAuthOptions);
         }
 
-        private HttpConfiguration ConfigureWebApi()
+        public HttpConfiguration ConfigureWebApi()
         {
             HttpConfiguration config = new HttpConfiguration();
 

--- a/DevelopGitHub/GitHubExtension/GitHubExtension.Infrastructure.Constants/RouteConstants.cs
+++ b/DevelopGitHub/GitHubExtension/GitHubExtension.Infrastructure.Constants/RouteConstants.cs
@@ -14,6 +14,8 @@
         // route prefixes
         public const string ApiRoles = "api/roles";
 
+        public const string ApiNote = "api/note";
+
         public const string ApiUser = "api/user";
 
         public const string AssignRolesToUser = ApiRepository + RepositoryId + Collaborators + GitHubId;
@@ -42,6 +44,10 @@
 
         public const string UpdateProject = ApiRepository + Current;
 
+        public const string CreateNoteForCollaborator = ApiNote;
+
+        public const string GetNoteForCollaborator = ApiNote + Collaborators + CollaboratorId;
+
         // segments
         public const string IdInt = "/{id:int}";
 
@@ -58,10 +64,13 @@
 
         public const string RepositoryId = "/{repoId}";
 
+        public const string CollaboratorId = "/{collaboratorId}";
+
         public const string RepositoryName = "/{repoName}";
 
         public const string User = "user";
 
         public const string UserName = "/{username}";
+;
     }
 }

--- a/DevelopGitHub/GitHubExtension/GitHubExtension.Infrastructure.Constants/RouteConstants.cs
+++ b/DevelopGitHub/GitHubExtension/GitHubExtension.Infrastructure.Constants/RouteConstants.cs
@@ -71,6 +71,5 @@
         public const string User = "user";
 
         public const string UserName = "/{username}";
-;
     }
 }

--- a/DevelopGitHub/GitHubExtension/GitHubExtension.Notes.Tests/Extensions/IdentityExtensions.cs
+++ b/DevelopGitHub/GitHubExtension/GitHubExtension.Notes.Tests/Extensions/IdentityExtensions.cs
@@ -1,0 +1,18 @@
+﻿using System.Security.Claims;
+using System.Security.Principal;
+using System.Web.Http;
+using NSubstitute;
+
+namespace GitHubExtension.Notes.Tests.Extensions
+{
+    public static class IdentityExtensions
+    {
+        public static void SetUserForController(this ApiController controller, string name, string typeOfClaim, string valueOfClaim)
+        {
+            var identity = Substitute.ForPartsOf<GenericIdentity>(name);
+            identity.AddClaim(new Claim(typeOfClaim, valueOfClaim));
+            var principal = Substitute.ForPartsOf<GenericPrincipal>(identity, new[] { "user" });
+            controller.User = principal;
+        }
+    }
+}

--- a/DevelopGitHub/GitHubExtension/GitHubExtension.Notes.Tests/Extensions/IdentityExtensions.cs
+++ b/DevelopGitHub/GitHubExtension/GitHubExtension.Notes.Tests/Extensions/IdentityExtensions.cs
@@ -1,7 +1,6 @@
 ﻿using System.Security.Claims;
 using System.Security.Principal;
 using System.Web.Http;
-using NSubstitute;
 
 namespace GitHubExtension.Notes.Tests.Extensions
 {
@@ -9,9 +8,9 @@ namespace GitHubExtension.Notes.Tests.Extensions
     {
         public static void SetUserForController(this ApiController controller, string name, string typeOfClaim, string valueOfClaim)
         {
-            var identity = Substitute.ForPartsOf<GenericIdentity>(name);
+            var identity = new GenericIdentity(name);
             identity.AddClaim(new Claim(typeOfClaim, valueOfClaim));
-            var principal = Substitute.ForPartsOf<GenericPrincipal>(identity, new[] { "user" });
+            var principal = new GenericPrincipal(identity, new[] { "user" });
             controller.User = principal;
         }
     }

--- a/DevelopGitHub/GitHubExtension/GitHubExtension.Notes.Tests/GitHubExtension.Notes.Tests.csproj
+++ b/DevelopGitHub/GitHubExtension/GitHubExtension.Notes.Tests/GitHubExtension.Notes.Tests.csproj
@@ -1,0 +1,136 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="..\packages\xunit.runner.visualstudio.2.1.0\build\net20\xunit.runner.visualstudio.props" Condition="Exists('..\packages\xunit.runner.visualstudio.2.1.0\build\net20\xunit.runner.visualstudio.props')" />
+  <Import Project="..\packages\xunit.core.2.1.0\build\portable-net45+win8+wp8+wpa81\xunit.core.props" Condition="Exists('..\packages\xunit.core.2.1.0\build\portable-net45+win8+wp8+wpa81\xunit.core.props')" />
+  <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
+  <PropertyGroup>
+    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
+    <ProjectGuid>{FEF89135-5ECD-4D37-B19D-F6D3685411CA}</ProjectGuid>
+    <OutputType>Library</OutputType>
+    <AppDesignerFolder>Properties</AppDesignerFolder>
+    <RootNamespace>GitHubExtension.Notes.Tests</RootNamespace>
+    <AssemblyName>GitHubExtension.Notes.Tests</AssemblyName>
+    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
+    <FileAlignment>512</FileAlignment>
+    <NuGetPackageImportStamp>ee5f5e8a</NuGetPackageImportStamp>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
+    <DebugSymbols>true</DebugSymbols>
+    <DebugType>full</DebugType>
+    <Optimize>false</Optimize>
+    <OutputPath>bin\Debug\</OutputPath>
+    <DefineConstants>DEBUG;TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
+    <DebugType>pdbonly</DebugType>
+    <Optimize>true</Optimize>
+    <OutputPath>bin\Release\</OutputPath>
+    <DefineConstants>TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <ItemGroup>
+    <Reference Include="EntityFramework, Version=6.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089, processorArchitecture=MSIL">
+      <HintPath>..\packages\EntityFramework.6.1.3\lib\net45\EntityFramework.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="EntityFramework.SqlServer, Version=6.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089, processorArchitecture=MSIL">
+      <HintPath>..\packages\EntityFramework.6.1.3\lib\net45\EntityFramework.SqlServer.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="FluentAssertions, Version=4.4.0.0, Culture=neutral, PublicKeyToken=33f2691a05b67b6a, processorArchitecture=MSIL">
+      <HintPath>..\packages\FluentAssertions.4.4.0\lib\net45\FluentAssertions.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="FluentAssertions.Core, Version=4.4.0.0, Culture=neutral, PublicKeyToken=33f2691a05b67b6a, processorArchitecture=MSIL">
+      <HintPath>..\packages\FluentAssertions.4.4.0\lib\net45\FluentAssertions.Core.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="FluentValidation, Version=6.2.1.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\FluentValidation.6.2.1.0\lib\Net45\FluentValidation.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="Newtonsoft.Json, Version=6.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
+      <HintPath>..\packages\Newtonsoft.Json.6.0.4\lib\net45\Newtonsoft.Json.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="NSubstitute, Version=1.10.0.0, Culture=neutral, PublicKeyToken=92dd2e9066daa5ca, processorArchitecture=MSIL">
+      <HintPath>..\packages\NSubstitute.1.10.0.0\lib\net45\NSubstitute.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="System" />
+    <Reference Include="System.ComponentModel.DataAnnotations" />
+    <Reference Include="System.Core" />
+    <Reference Include="System.Net.Http" />
+    <Reference Include="System.Net.Http.Formatting, Version=5.2.3.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\packages\Microsoft.AspNet.WebApi.Client.5.2.3\lib\net45\System.Net.Http.Formatting.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="System.Web.Http, Version=5.2.3.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\packages\Microsoft.AspNet.WebApi.Core.5.2.3\lib\net45\System.Web.Http.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="System.Xml.Linq" />
+    <Reference Include="System.Data.DataSetExtensions" />
+    <Reference Include="Microsoft.CSharp" />
+    <Reference Include="System.Data" />
+    <Reference Include="System.Xml" />
+    <Reference Include="xunit.abstractions, Version=2.0.0.0, Culture=neutral, PublicKeyToken=8d05b1bb7a6fdb6c, processorArchitecture=MSIL">
+      <HintPath>..\packages\xunit.abstractions.2.0.0\lib\net35\xunit.abstractions.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="xunit.assert, Version=2.1.0.3179, Culture=neutral, PublicKeyToken=8d05b1bb7a6fdb6c, processorArchitecture=MSIL">
+      <HintPath>..\packages\xunit.assert.2.1.0\lib\portable-net45+win8+wp8+wpa81\xunit.assert.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="xunit.core, Version=2.1.0.3179, Culture=neutral, PublicKeyToken=8d05b1bb7a6fdb6c, processorArchitecture=MSIL">
+      <HintPath>..\packages\xunit.extensibility.core.2.1.0\lib\portable-net45+win8+wp8+wpa81\xunit.core.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="xunit.execution.desktop, Version=2.1.0.3179, Culture=neutral, PublicKeyToken=8d05b1bb7a6fdb6c, processorArchitecture=MSIL">
+      <HintPath>..\packages\xunit.extensibility.execution.2.1.0\lib\net45\xunit.execution.desktop.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+  </ItemGroup>
+  <ItemGroup>
+    <Compile Include="Properties\AssemblyInfo.cs" />
+    <Compile Include="TestsForControllers\NoteControllerCreateNoteTests.cs" />
+    <Compile Include="TestsForControllers\NoteControllerGetNoteTests.cs" />
+    <Compile Include="TestsForValidator\NoteValidatorTests.cs" />
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\GitHubExtension.Notes.DAL\GitHubExtension.Notes.DAL.csproj">
+      <Project>{72035e1a-fcfd-48f1-81dd-7dbc724dd8e9}</Project>
+      <Name>GitHubExtension.Notes.DAL</Name>
+    </ProjectReference>
+    <ProjectReference Include="..\GitHubExtension.Notes.WebApi\GitHubExtension.Notes.WebApi.csproj">
+      <Project>{819015c6-b19c-4240-9049-cafa965cef0d}</Project>
+      <Name>GitHubExtension.Notes.WebApi</Name>
+    </ProjectReference>
+  </ItemGroup>
+  <ItemGroup>
+    <None Include="app.config" />
+    <None Include="packages.config" />
+  </ItemGroup>
+  <ItemGroup>
+    <Service Include="{82A7F48D-3B50-4B1E-B82E-3ADA8210C358}" />
+  </ItemGroup>
+  <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
+  <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
+    <PropertyGroup>
+      <ErrorText>This project references NuGet package(s) that are missing on this computer. Enable NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
+    </PropertyGroup>
+    <Error Condition="!Exists('..\packages\xunit.core.2.1.0\build\portable-net45+win8+wp8+wpa81\xunit.core.props')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\xunit.core.2.1.0\build\portable-net45+win8+wp8+wpa81\xunit.core.props'))" />
+    <Error Condition="!Exists('..\packages\xunit.runner.visualstudio.2.1.0\build\net20\xunit.runner.visualstudio.props')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\xunit.runner.visualstudio.2.1.0\build\net20\xunit.runner.visualstudio.props'))" />
+  </Target>
+  <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
+       Other similar extension points exist, see Microsoft.Common.targets.
+  <Target Name="BeforeBuild">
+  </Target>
+  <Target Name="AfterBuild">
+  </Target>
+  -->
+</Project>

--- a/DevelopGitHub/GitHubExtension/GitHubExtension.Notes.Tests/GitHubExtension.Notes.Tests.csproj
+++ b/DevelopGitHub/GitHubExtension/GitHubExtension.Notes.Tests/GitHubExtension.Notes.Tests.csproj
@@ -33,14 +33,6 @@
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="EntityFramework, Version=6.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089, processorArchitecture=MSIL">
-      <HintPath>..\packages\EntityFramework.6.1.3\lib\net45\EntityFramework.dll</HintPath>
-      <Private>True</Private>
-    </Reference>
-    <Reference Include="EntityFramework.SqlServer, Version=6.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089, processorArchitecture=MSIL">
-      <HintPath>..\packages\EntityFramework.6.1.3\lib\net45\EntityFramework.SqlServer.dll</HintPath>
-      <Private>True</Private>
-    </Reference>
     <Reference Include="FluentAssertions, Version=4.4.0.0, Culture=neutral, PublicKeyToken=33f2691a05b67b6a, processorArchitecture=MSIL">
       <HintPath>..\packages\FluentAssertions.4.4.0\lib\net45\FluentAssertions.dll</HintPath>
       <Private>True</Private>
@@ -53,8 +45,16 @@
       <HintPath>..\packages\FluentValidation.6.2.1.0\lib\Net45\FluentValidation.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="Newtonsoft.Json, Version=6.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
-      <HintPath>..\packages\Newtonsoft.Json.6.0.4\lib\net45\Newtonsoft.Json.dll</HintPath>
+    <Reference Include="Microsoft.Web.Infrastructure, Version=1.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\packages\Microsoft.Web.Infrastructure.1.0.0.0\lib\net40\Microsoft.Web.Infrastructure.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="MvcRouteTester, Version=1.0.1.1, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\MvcRouteTester.Mvc5.2.2.0.1\lib\net45\MvcRouteTester.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="Newtonsoft.Json, Version=8.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
+      <HintPath>..\packages\Newtonsoft.Json.8.0.3\lib\net45\Newtonsoft.Json.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="NSubstitute, Version=1.10.0.0, Culture=neutral, PublicKeyToken=92dd2e9066daa5ca, processorArchitecture=MSIL">
@@ -62,21 +62,42 @@
       <Private>True</Private>
     </Reference>
     <Reference Include="System" />
-    <Reference Include="System.ComponentModel.DataAnnotations" />
     <Reference Include="System.Core" />
     <Reference Include="System.Net.Http" />
     <Reference Include="System.Net.Http.Formatting, Version=5.2.3.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <HintPath>..\packages\Microsoft.AspNet.WebApi.Client.5.2.3\lib\net45\System.Net.Http.Formatting.dll</HintPath>
       <Private>True</Private>
     </Reference>
+    <Reference Include="System.Web" />
+    <Reference Include="System.Web.Helpers, Version=3.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\packages\Microsoft.AspNet.WebPages.3.2.3\lib\net45\System.Web.Helpers.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
     <Reference Include="System.Web.Http, Version=5.2.3.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <HintPath>..\packages\Microsoft.AspNet.WebApi.Core.5.2.3\lib\net45\System.Web.Http.dll</HintPath>
       <Private>True</Private>
     </Reference>
+    <Reference Include="System.Web.Mvc, Version=5.2.3.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\packages\Microsoft.AspNet.Mvc.5.2.3\lib\net45\System.Web.Mvc.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="System.Web.Razor, Version=3.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\packages\Microsoft.AspNet.Razor.3.2.3\lib\net45\System.Web.Razor.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="System.Web.WebPages, Version=3.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\packages\Microsoft.AspNet.WebPages.3.2.3\lib\net45\System.Web.WebPages.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="System.Web.WebPages.Deployment, Version=3.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\packages\Microsoft.AspNet.WebPages.3.2.3\lib\net45\System.Web.WebPages.Deployment.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="System.Web.WebPages.Razor, Version=3.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\packages\Microsoft.AspNet.WebPages.3.2.3\lib\net45\System.Web.WebPages.Razor.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
     <Reference Include="System.Xml.Linq" />
-    <Reference Include="System.Data.DataSetExtensions" />
-    <Reference Include="Microsoft.CSharp" />
-    <Reference Include="System.Data" />
     <Reference Include="System.Xml" />
     <Reference Include="xunit.abstractions, Version=2.0.0.0, Culture=neutral, PublicKeyToken=8d05b1bb7a6fdb6c, processorArchitecture=MSIL">
       <HintPath>..\packages\xunit.abstractions.2.0.0\lib\net35\xunit.abstractions.dll</HintPath>
@@ -96,12 +117,24 @@
     </Reference>
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="Extensions\IdentityExtensions.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
+    <Compile Include="TestNoteRoutesConfig.cs" />
     <Compile Include="TestsForControllers\NoteControllerCreateNoteTests.cs" />
     <Compile Include="TestsForControllers\NoteControllerGetNoteTests.cs" />
+    <Compile Include="TestsForRoutes\NoteRouteTests.cs" />
+    <Compile Include="TestsForRoutes\TestRoutesMappers\ForGetNoteForCollaborator.cs" />
     <Compile Include="TestsForValidator\NoteValidatorTests.cs" />
   </ItemGroup>
   <ItemGroup>
+    <ProjectReference Include="..\GitHubExtension.EntryPoint\GitHubExtension.EntryPoint.csproj">
+      <Project>{B5F77285-E213-4564-BD65-CAA3242F9F5B}</Project>
+      <Name>GitHubExtension.EntryPoint</Name>
+    </ProjectReference>
+    <ProjectReference Include="..\GitHubExtension.Infrastructure.Constants\GitHubExtension.Infrastructure.Constants.csproj">
+      <Project>{642455c5-0a4b-4e25-a2c3-1f1304a0d7dd}</Project>
+      <Name>GitHubExtension.Infrastructure.Constants</Name>
+    </ProjectReference>
     <ProjectReference Include="..\GitHubExtension.Notes.DAL\GitHubExtension.Notes.DAL.csproj">
       <Project>{72035e1a-fcfd-48f1-81dd-7dbc724dd8e9}</Project>
       <Name>GitHubExtension.Notes.DAL</Name>
@@ -118,6 +151,7 @@
   <ItemGroup>
     <Service Include="{82A7F48D-3B50-4B1E-B82E-3ADA8210C358}" />
   </ItemGroup>
+  <ItemGroup />
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
     <PropertyGroup>

--- a/DevelopGitHub/GitHubExtension/GitHubExtension.Notes.Tests/Properties/AssemblyInfo.cs
+++ b/DevelopGitHub/GitHubExtension/GitHubExtension.Notes.Tests/Properties/AssemblyInfo.cs
@@ -1,0 +1,36 @@
+﻿using System.Reflection;
+using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
+
+// General Information about an assembly is controlled through the following 
+// set of attributes. Change these attribute values to modify the information
+// associated with an assembly.
+[assembly: AssemblyTitle("GitHubExtension.Notes.Tests")]
+[assembly: AssemblyDescription("")]
+[assembly: AssemblyConfiguration("")]
+[assembly: AssemblyCompany("")]
+[assembly: AssemblyProduct("GitHubExtension.Notes.Tests")]
+[assembly: AssemblyCopyright("Copyright ©  2016")]
+[assembly: AssemblyTrademark("")]
+[assembly: AssemblyCulture("")]
+
+// Setting ComVisible to false makes the types in this assembly not visible 
+// to COM components.  If you need to access a type in this assembly from 
+// COM, set the ComVisible attribute to true on that type.
+[assembly: ComVisible(false)]
+
+// The following GUID is for the ID of the typelib if this project is exposed to COM
+[assembly: Guid("430a0b71-4b91-4dde-a414-e16850356606")]
+
+// Version information for an assembly consists of the following four values:
+//
+//      Major Version
+//      Minor Version 
+//      Build Number
+//      Revision
+//
+// You can specify all the values or you can default the Build and Revision Numbers 
+// by using the '*' as shown below:
+// [assembly: AssemblyVersion("1.0.*")]
+[assembly: AssemblyVersion("1.0.0.0")]
+[assembly: AssemblyFileVersion("1.0.0.0")]

--- a/DevelopGitHub/GitHubExtension/GitHubExtension.Notes.Tests/TestNoteRoutesConfig.cs
+++ b/DevelopGitHub/GitHubExtension/GitHubExtension.Notes.Tests/TestNoteRoutesConfig.cs
@@ -1,0 +1,23 @@
+﻿using System.Web.Http;
+using GitHubExtension.EntryPoint;
+
+namespace GitHubExtension.Notes.Tests
+{
+    public class TestNoteRoutesConfig
+    {
+        public string url = "/";
+
+        public TestNoteRoutesConfig(string url)
+        {
+            url = url;
+        }
+
+        public HttpConfiguration GetRoutes()
+        {
+            var config = new Startup();
+            var routes = config.ConfigureWebApi();
+            routes.EnsureInitialized();
+            return routes;
+        }
+    }
+}

--- a/DevelopGitHub/GitHubExtension/GitHubExtension.Notes.Tests/TestNoteRoutesConfig.cs
+++ b/DevelopGitHub/GitHubExtension/GitHubExtension.Notes.Tests/TestNoteRoutesConfig.cs
@@ -7,11 +7,6 @@ namespace GitHubExtension.Notes.Tests
     {
         public string url = "/";
 
-        public TestNoteRoutesConfig(string url)
-        {
-            url = url;
-        }
-
         public HttpConfiguration GetRoutes()
         {
             var config = new Startup();

--- a/DevelopGitHub/GitHubExtension/GitHubExtension.Notes.Tests/TestsForControllers/NoteControllerCreateNoteTests.cs
+++ b/DevelopGitHub/GitHubExtension/GitHubExtension.Notes.Tests/TestsForControllers/NoteControllerCreateNoteTests.cs
@@ -21,7 +21,7 @@ namespace GitHubExtension.Notes.Tests.TestsForControllers
         private const string TestCollaboratorId = "550e8400-e29b-41d4-a716-446655440000";
         private const string TypeOfClaim = "http://schemas.xmlsoap.org/ws/2005/05/identity/claims/nameidentifier";
         
-        public static IEnumerable<object[]> DataForModel
+        public static IEnumerable<object[]> DataForAddNoteModel
         {
             get
             {
@@ -40,7 +40,7 @@ namespace GitHubExtension.Notes.Tests.TestsForControllers
         }
 
         [Theory]
-        [MemberData("DataForModel")]
+        [MemberData("DataForAddNoteModel")]
         public void ShouldReturnOkResponseWhenIdentityContainsUser(IEnumerable<AddNoteModel> model)
         {
             // Arrange
@@ -57,7 +57,7 @@ namespace GitHubExtension.Notes.Tests.TestsForControllers
         }
 
         [Theory]
-        [MemberData("DataForModel")]
+        [MemberData("DataForAddNoteModel")]
         public void ShouldReturnBadRequestWhenIdentityContainsNoUser(IEnumerable<AddNoteModel> model)
         {
             // Arrange
@@ -72,7 +72,7 @@ namespace GitHubExtension.Notes.Tests.TestsForControllers
         }
 
         [Theory]
-        [MemberData("DataForModel")]
+        [MemberData("DataForAddNoteModel")]
         public void NoteCommanShouldReceiveACallWhenIdentitySet(IEnumerable<AddNoteModel> model)
         {
             // Arrange
@@ -88,7 +88,7 @@ namespace GitHubExtension.Notes.Tests.TestsForControllers
         }
 
         [Theory]
-        [MemberData("DataForModel")]
+        [MemberData("DataForAddNoteModel")]
         public void NoteCommanShouldNotReceiveACallWhenNoUser(IEnumerable<AddNoteModel> model)
         {
             // Arrange

--- a/DevelopGitHub/GitHubExtension/GitHubExtension.Notes.Tests/TestsForControllers/NoteControllerCreateNoteTests.cs
+++ b/DevelopGitHub/GitHubExtension/GitHubExtension.Notes.Tests/TestsForControllers/NoteControllerCreateNoteTests.cs
@@ -1,0 +1,105 @@
+﻿using System.Collections.Generic;
+using System.Linq;
+using System.Web.Http.Results;
+using FluentAssertions;
+using GitHubExtension.Notes.DAL.Model;
+using GitHubExtension.Notes.Tests.Extensions;
+using GitHubExtension.Notes.WebApi.Commands;
+using GitHubExtension.Notes.WebApi.Controllers;
+using GitHubExtension.Notes.WebApi.Queries;
+using GitHubExtension.Notes.WebApi.ViewModels;
+using NSubstitute;
+using Xunit;
+
+namespace GitHubExtension.Notes.Tests.TestsForControllers
+{
+    public class NoteControllerCreateNoteTests
+    {
+        private const string TestNoteBody = "Note Body";
+        private const string TestUserId = "550e8400-e29b-41d4-a716-446655441111";
+        private const string TestUserName = "Test";
+        private const string TestCollaboratorId = "550e8400-e29b-41d4-a716-446655440000";
+        private const string TypeOfClaim = "http://schemas.xmlsoap.org/ws/2005/05/identity/claims/nameidentifier";
+        
+        public static IEnumerable<object[]> DataForModel
+        {
+            get
+            {
+                yield return new object[]
+                {
+                    new List<AddNoteModel>
+                    {
+                        new AddNoteModel()
+                        {
+                            CollaboratorId = TestCollaboratorId,
+                            Body = TestNoteBody
+                        }
+                    }
+                };
+            }
+        }
+
+        [Theory]
+        [MemberData("DataForModel")]
+        public void ShouldReturnOkResponseWhenIdentityContainsUser(IEnumerable<AddNoteModel> model)
+        {
+            // Arrange
+            var noteController = new NoteController(Substitute.For<INoteCommands>(), Substitute.For<INoteQueries>());
+            noteController.SetUserForController(TestUserName, TypeOfClaim, TestUserId);
+           
+            // Act
+            var response = noteController.CreateNote(model.FirstOrDefault());
+            var result = response.Result;
+
+
+            // Assert
+            result.Should().BeOfType<OkNegotiatedContentResult<Note>>();
+        }
+
+        [Theory]
+        [MemberData("DataForModel")]
+        public void ShouldReturnBadRequestWhenIdentityContainsNoUser(IEnumerable<AddNoteModel> model)
+        {
+            // Arrange
+            var noteController = new NoteController(Substitute.For<INoteCommands>(), Substitute.For<INoteQueries>());
+
+            // Act
+            var response = noteController.CreateNote(model.FirstOrDefault());
+            var result = response.Result;
+
+            // Assert
+            result.Should().BeOfType<InvalidModelStateResult>();
+        }
+
+        [Theory]
+        [MemberData("DataForModel")]
+        public void NoteCommanShouldReceiveACallWhenIdentitySet(IEnumerable<AddNoteModel> model)
+        {
+            // Arrange
+            var noteCommand = Substitute.For<INoteCommands>();
+            var noteController = new NoteController(noteCommand, Substitute.For<INoteQueries>());
+            noteController.SetUserForController(TestUserName, TypeOfClaim, TestUserId);
+
+            // Act
+            noteController.CreateNote(model.FirstOrDefault());
+
+            // Assert
+            noteCommand.ReceivedWithAnyArgs().AddNote(new Note{});
+        }
+
+        [Theory]
+        [MemberData("DataForModel")]
+        public void NoteCommanShouldNotReceiveACallWhenNoUser(IEnumerable<AddNoteModel> model)
+        {
+            // Arrange
+            var noteCommand = Substitute.For<INoteCommands>();
+            var noteController = new NoteController(noteCommand, Substitute.For<INoteQueries>());
+
+            // Act
+            noteController.CreateNote(model.Single());
+
+            // Assert
+            noteCommand.DidNotReceiveWithAnyArgs().AddNote(new Note{});
+        }
+    }
+}

--- a/DevelopGitHub/GitHubExtension/GitHubExtension.Notes.Tests/TestsForControllers/NoteControllerGetNoteTests.cs
+++ b/DevelopGitHub/GitHubExtension/GitHubExtension.Notes.Tests/TestsForControllers/NoteControllerGetNoteTests.cs
@@ -1,0 +1,117 @@
+﻿using System.Collections.Generic;
+using System.Linq;
+using System.Web.Http.Results;
+using FluentAssertions;
+using GitHubExtension.Notes.DAL.Model;
+using GitHubExtension.Notes.Tests.Extensions;
+using GitHubExtension.Notes.WebApi.Commands;
+using GitHubExtension.Notes.WebApi.Controllers;
+using GitHubExtension.Notes.WebApi.Queries;
+using GitHubExtension.Notes.WebApi.ViewModels;
+using NSubstitute;
+using Xunit;
+
+namespace GitHubExtension.Notes.Tests.TestsForControllers
+{
+    public class NoteControllerGetNoteTests
+    {
+        private const string TestUserId = "550e8400-e29b-41d4-a716-446655441111";
+        private const string TestUserName = "Test";
+        private const string TestCollaboratorId = "550e8400-e29b-41d4-a716-446655440000";
+        private const string TestNoteBody = "Test note body";
+        private const string TypeOfClaim = "http://schemas.xmlsoap.org/ws/2005/05/identity/claims/nameidentifier";
+
+        public static IEnumerable<object[]> DataForNotFoundResult
+        {
+            get
+            {
+                yield return new object[] 
+                {
+                    new List<Note>
+                    {
+                        new Note
+                        {
+                            UserId = "testNotFound",
+                            CollaboratorId = "testNotFound",
+                            Body = null
+                        }
+                    }
+                };
+            }
+        }
+
+        public static IEnumerable<object[]> DataForOkResult
+        {
+            get
+            {
+                yield return new object[]
+                {
+                    new List<Note>
+                    {
+                        new Note
+                        {
+                            UserId = TestUserId,
+                            CollaboratorId = TestCollaboratorId,
+                            Body = TestNoteBody
+                        }
+                    }
+                };
+            }
+        }
+
+        private static INoteQueries MockForNoteQueriesContext(IEnumerable<Note> notes)
+        {
+            var context = notes.AsQueryable().OrderBy(x => x.Id);
+            var noteQueriesContext = Substitute.For<INoteQueries>();
+            noteQueriesContext.Notes.Returns(context);
+            return noteQueriesContext;
+        }
+
+        [Theory]
+        [MemberData("DataForOkResult")]
+        public void ShouldReturnOkResultWhenNoteExists(IEnumerable<Note> notes)
+        {
+            // Arrange
+            var noteQuieriesContext = MockForNoteQueriesContext(notes);
+            var noteController = new NoteController(Substitute.For<INoteCommands>(), noteQuieriesContext);
+            noteController.SetUserForController(TestUserName, TypeOfClaim, TestUserId);
+
+            // Act
+            var response = noteController.GetNote(TestCollaboratorId);
+
+            // Assert
+            response.Should().BeOfType<OkNegotiatedContentResult<NoteModel>>();
+        }
+
+        [Theory]
+        [MemberData("DataForOkResult")]
+        public void ShouldReturnBadRequestWhenNoUser(IEnumerable<Note> notes)
+        {
+            // Arrange
+            var noteQuieriesContext = MockForNoteQueriesContext(notes);
+            var noteController = new NoteController(Substitute.For<INoteCommands>(), noteQuieriesContext);
+
+            // Act
+            var response = noteController.GetNote(TestCollaboratorId);
+
+            // Assert
+            response.Should().BeOfType<InvalidModelStateResult>();
+        }
+
+        [Theory]
+        [MemberData("DataForNotFoundResult")]
+        public void ShouldReturnNotFoundResultWhenNoteDoesNotExist(IEnumerable<Note> notes)
+        {
+            // Arrange
+            var noteQuieriesContext = MockForNoteQueriesContext(notes);
+            var noteController = new NoteController(Substitute.For<INoteCommands>(), noteQuieriesContext);
+            noteController.SetUserForController(TestUserName, TypeOfClaim, TestUserId);
+
+            // Act
+            var response = noteController.GetNote(TestCollaboratorId);
+
+            // Assert
+            response.Should().BeOfType<NotFoundResult>();
+        }
+    }
+}

--- a/DevelopGitHub/GitHubExtension/GitHubExtension.Notes.Tests/TestsForRoutes/NoteRouteTests.cs
+++ b/DevelopGitHub/GitHubExtension/GitHubExtension.Notes.Tests/TestsForRoutes/NoteRouteTests.cs
@@ -1,0 +1,33 @@
+﻿using System.Net.Http;
+using GitHubExtension.Infrastructure.Constants;
+using GitHubExtension.Notes.Tests.TestsForRoutes.TestRoutesMappers;
+using GitHubExtension.Notes.WebApi.Controllers;
+using GitHubExtension.Notes.WebApi.ViewModels;
+using MvcRouteTester;
+using Xunit;
+
+namespace GitHubExtension.Notes.Tests.TestsForRoutes
+{
+    public class NoteRouteTests : TestNoteRoutesConfig
+    {
+        public NoteRouteTests() : base(RouteConstants.ApiNote)
+        {
+        }
+
+        [Fact]
+        public void GetNoteForCollaboratorRoute()
+        {
+            url = url.ForGetNoteForCollaborator();
+            var routes = GetRoutes();
+            routes.ShouldMap(url).To<NoteController>(HttpMethod.Get, x => x.GetNote("550e8400-e29b-41d4-a716-446655440000"));
+        }
+
+        [Fact]
+        public void CreateNoteForCollaboratorRoute()
+        {
+            url = url.ForCreateNoteForCollaborator();
+            var routes = GetRoutes();
+            routes.ShouldMap(url).WithFormUrlBody("CollaboratorId=550e8400-e29b-41d4-a716-446655440000&Body=TestBody").To<NoteController>(HttpMethod.Post, x=>x.CreateNote(new AddNoteModel()));
+        }
+    }
+}

--- a/DevelopGitHub/GitHubExtension/GitHubExtension.Notes.Tests/TestsForRoutes/NoteRouteTests.cs
+++ b/DevelopGitHub/GitHubExtension/GitHubExtension.Notes.Tests/TestsForRoutes/NoteRouteTests.cs
@@ -10,24 +10,18 @@ namespace GitHubExtension.Notes.Tests.TestsForRoutes
 {
     public class NoteRouteTests : TestNoteRoutesConfig
     {
-        public NoteRouteTests() : base(RouteConstants.ApiNote)
-        {
-        }
-
         [Fact]
         public void GetNoteForCollaboratorRoute()
         {
             url = url.ForGetNoteForCollaborator();
-            var routes = GetRoutes();
-            routes.ShouldMap(url).To<NoteController>(HttpMethod.Get, x => x.GetNote("550e8400-e29b-41d4-a716-446655440000"));
+            GetRoutes().ShouldMap(url).To<NoteController>(HttpMethod.Get, x => x.GetNote("550e8400-e29b-41d4-a716-446655440000"));
         }
 
         [Fact]
         public void CreateNoteForCollaboratorRoute()
         {
             url = url.ForCreateNoteForCollaborator();
-            var routes = GetRoutes();
-            routes.ShouldMap(url).WithFormUrlBody("CollaboratorId=550e8400-e29b-41d4-a716-446655440000&Body=TestBody").To<NoteController>(HttpMethod.Post, x=>x.CreateNote(new AddNoteModel()));
+            GetRoutes().ShouldMap(url).WithFormUrlBody("CollaboratorId=550e8400-e29b-41d4-a716-446655440000&Body=TestBody").To<NoteController>(HttpMethod.Post, x=>x.CreateNote(new AddNoteModel()));
         }
     }
 }

--- a/DevelopGitHub/GitHubExtension/GitHubExtension.Notes.Tests/TestsForRoutes/TestRoutesMappers/ForGetNoteForCollaborator.cs
+++ b/DevelopGitHub/GitHubExtension/GitHubExtension.Notes.Tests/TestsForRoutes/TestRoutesMappers/ForGetNoteForCollaborator.cs
@@ -1,0 +1,21 @@
+﻿using System.Text.RegularExpressions;
+using GitHubExtension.Infrastructure.Constants;
+
+namespace GitHubExtension.Notes.Tests.TestsForRoutes.TestRoutesMappers
+{
+    public static class NoteTestRoutesMappers
+    {
+        public static string ForGetNoteForCollaborator(this string url)
+        {
+            return url + Regex.Replace(
+                RouteConstants.GetNoteForCollaborator,
+                RouteConstants.CollaboratorId,
+                "/550e8400-e29b-41d4-a716-446655440000");
+        }
+
+        public static string ForCreateNoteForCollaborator(this string url)
+        {
+            return url + RouteConstants.CreateNoteForCollaborator;
+        }
+    }
+}

--- a/DevelopGitHub/GitHubExtension/GitHubExtension.Notes.Tests/TestsForValidator/NoteValidatorTests.cs
+++ b/DevelopGitHub/GitHubExtension/GitHubExtension.Notes.Tests/TestsForValidator/NoteValidatorTests.cs
@@ -21,14 +21,14 @@ namespace GitHubExtension.Notes.Tests.TestsForValidator
         }
 
         [Fact]
-        public void ShouldNotHaveErrorWhenBodyIsSpecified()
+        public void ValidModelWhenBodyIsSpecified()
         {
             var noteValidator = new AddNoteModelValidator();
             noteValidator.ShouldNotHaveValidationErrorFor(note => note.Body, "Great Coder");
         }
 
         [Fact]
-        public void ShouldNotHaveErrorWhenCollaboratorIdIsSpecified()
+        public void ValidModelWhenCollaboratorIdIsSpecified()
         {
             var noteValidator = new AddNoteModelValidator();
             noteValidator.ShouldNotHaveValidationErrorFor(note => note.Body, "550e8400-e29b-41d4-a716-446655440000");

--- a/DevelopGitHub/GitHubExtension/GitHubExtension.Notes.Tests/TestsForValidator/NoteValidatorTests.cs
+++ b/DevelopGitHub/GitHubExtension/GitHubExtension.Notes.Tests/TestsForValidator/NoteValidatorTests.cs
@@ -1,0 +1,37 @@
+﻿using FluentValidation.TestHelper;
+using GitHubExtension.Notes.WebApi.Validators;
+using Xunit;
+
+namespace GitHubExtension.Notes.Tests.TestsForValidator
+{
+    public class NoteValidatorTests
+    {
+        [Fact]
+        public void ShoulHaveErrorWhenBodyIsNull()
+        {
+            var noteValidator = new AddNoteModelValidator();
+            noteValidator.ShouldHaveValidationErrorFor(note => note.Body, null as string);
+        }
+
+        [Fact]
+        public void ShoulHaveErrorWhenCollaboratorIdIsNull()
+        {
+            var noteValidator = new AddNoteModelValidator();
+            noteValidator.ShouldHaveValidationErrorFor(note => note.CollaboratorId, null as string);
+        }
+
+        [Fact]
+        public void ShouldNotHaveErrorWhenBodyIsSpecified()
+        {
+            var noteValidator = new AddNoteModelValidator();
+            noteValidator.ShouldNotHaveValidationErrorFor(note => note.Body, "Great Coder");
+        }
+
+        [Fact]
+        public void ShouldNotHaveErrorWhenCollaboratorIdIsSpecified()
+        {
+            var noteValidator = new AddNoteModelValidator();
+            noteValidator.ShouldNotHaveValidationErrorFor(note => note.Body, "550e8400-e29b-41d4-a716-446655440000");
+        }
+    }
+}

--- a/DevelopGitHub/GitHubExtension/GitHubExtension.Notes.Tests/app.config
+++ b/DevelopGitHub/GitHubExtension/GitHubExtension.Notes.Tests/app.config
@@ -1,0 +1,25 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<configuration>
+  <configSections>
+    <!-- For more information on Entity Framework configuration, visit http://go.microsoft.com/fwlink/?LinkID=237468 -->
+    <section name="entityFramework" type="System.Data.Entity.Internal.ConfigFile.EntityFrameworkSection, EntityFramework, Version=6.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089" requirePermission="false" />
+  </configSections>
+  <runtime>
+    <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
+      <dependentAssembly>
+        <assemblyIdentity name="System.Web.Http" publicKeyToken="31bf3856ad364e35" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-5.2.3.0" newVersion="5.2.3.0" />
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="System.Net.Http.Formatting" publicKeyToken="31bf3856ad364e35" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-5.2.3.0" newVersion="5.2.3.0" />
+      </dependentAssembly>
+    </assemblyBinding>
+  </runtime>
+  <entityFramework>
+    <defaultConnectionFactory type="System.Data.Entity.Infrastructure.SqlConnectionFactory, EntityFramework" />
+    <providers>
+      <provider invariantName="System.Data.SqlClient" type="System.Data.Entity.SqlServer.SqlProviderServices, EntityFramework.SqlServer" />
+    </providers>
+  </entityFramework>
+</configuration>

--- a/DevelopGitHub/GitHubExtension/GitHubExtension.Notes.Tests/app.config
+++ b/DevelopGitHub/GitHubExtension/GitHubExtension.Notes.Tests/app.config
@@ -14,6 +14,30 @@
         <assemblyIdentity name="System.Net.Http.Formatting" publicKeyToken="31bf3856ad364e35" culture="neutral" />
         <bindingRedirect oldVersion="0.0.0.0-5.2.3.0" newVersion="5.2.3.0" />
       </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="Microsoft.Owin" publicKeyToken="31bf3856ad364e35" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-3.0.1.0" newVersion="3.0.1.0" />
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="Microsoft.Owin.Security.OAuth" publicKeyToken="31bf3856ad364e35" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-3.0.1.0" newVersion="3.0.1.0" />
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="Microsoft.Owin.Security" publicKeyToken="31bf3856ad364e35" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-3.0.1.0" newVersion="3.0.1.0" />
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="Microsoft.Owin.Security.Cookies" publicKeyToken="31bf3856ad364e35" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-3.0.1.0" newVersion="3.0.1.0" />
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="Newtonsoft.Json" publicKeyToken="30ad4fe6b2a6aeed" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-8.0.0.0" newVersion="8.0.0.0" />
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="System.Web.Mvc" publicKeyToken="31bf3856ad364e35" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-5.2.3.0" newVersion="5.2.3.0" />
+      </dependentAssembly>
     </assemblyBinding>
   </runtime>
   <entityFramework>

--- a/DevelopGitHub/GitHubExtension/GitHubExtension.Notes.Tests/packages.config
+++ b/DevelopGitHub/GitHubExtension/GitHubExtension.Notes.Tests/packages.config
@@ -1,0 +1,17 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<packages>
+  <package id="EntityFramework" version="6.1.3" targetFramework="net45" />
+  <package id="FluentAssertions" version="4.4.0" targetFramework="net45" />
+  <package id="FluentValidation" version="6.2.1.0" targetFramework="net45" />
+  <package id="Microsoft.AspNet.WebApi.Client" version="5.2.3" targetFramework="net45" />
+  <package id="Microsoft.AspNet.WebApi.Core" version="5.2.3" targetFramework="net45" />
+  <package id="Newtonsoft.Json" version="6.0.4" targetFramework="net45" />
+  <package id="NSubstitute" version="1.10.0.0" targetFramework="net45" />
+  <package id="xunit" version="2.1.0" targetFramework="net45" />
+  <package id="xunit.abstractions" version="2.0.0" targetFramework="net45" />
+  <package id="xunit.assert" version="2.1.0" targetFramework="net45" />
+  <package id="xunit.core" version="2.1.0" targetFramework="net45" />
+  <package id="xunit.extensibility.core" version="2.1.0" targetFramework="net45" />
+  <package id="xunit.extensibility.execution" version="2.1.0" targetFramework="net45" />
+  <package id="xunit.runner.visualstudio" version="2.1.0" targetFramework="net45" />
+</packages>

--- a/DevelopGitHub/GitHubExtension/GitHubExtension.Notes.Tests/packages.config
+++ b/DevelopGitHub/GitHubExtension/GitHubExtension.Notes.Tests/packages.config
@@ -3,9 +3,14 @@
   <package id="EntityFramework" version="6.1.3" targetFramework="net45" />
   <package id="FluentAssertions" version="4.4.0" targetFramework="net45" />
   <package id="FluentValidation" version="6.2.1.0" targetFramework="net45" />
+  <package id="Microsoft.AspNet.Mvc" version="5.2.3" targetFramework="net45" />
+  <package id="Microsoft.AspNet.Razor" version="3.2.3" targetFramework="net45" />
   <package id="Microsoft.AspNet.WebApi.Client" version="5.2.3" targetFramework="net45" />
   <package id="Microsoft.AspNet.WebApi.Core" version="5.2.3" targetFramework="net45" />
-  <package id="Newtonsoft.Json" version="6.0.4" targetFramework="net45" />
+  <package id="Microsoft.AspNet.WebPages" version="3.2.3" targetFramework="net45" />
+  <package id="Microsoft.Web.Infrastructure" version="1.0.0.0" targetFramework="net45" />
+  <package id="MvcRouteTester.Mvc5.2" version="2.0.1" targetFramework="net45" />
+  <package id="Newtonsoft.Json" version="8.0.3" targetFramework="net45" />
   <package id="NSubstitute" version="1.10.0.0" targetFramework="net45" />
   <package id="xunit" version="2.1.0" targetFramework="net45" />
   <package id="xunit.abstractions" version="2.0.0" targetFramework="net45" />

--- a/DevelopGitHub/GitHubExtension/GitHubExtension.Notes.WebApi/Constants/NotesRouteConstants.cs
+++ b/DevelopGitHub/GitHubExtension/GitHubExtension.Notes.WebApi/Constants/NotesRouteConstants.cs
@@ -1,9 +1,0 @@
-﻿namespace GitHubExtension.Notes.WebApi.Constants
-{
-    public class NotesRouteConstants
-    {
-        public const string CreateNoteRoute = "api/note";
-
-        public const string GetNoteRoute = "api/note/collaborators/{collaboratorId}";
-    }
-}

--- a/DevelopGitHub/GitHubExtension/GitHubExtension.Notes.WebApi/Controllers/NoteController.cs
+++ b/DevelopGitHub/GitHubExtension/GitHubExtension.Notes.WebApi/Controllers/NoteController.cs
@@ -1,8 +1,10 @@
 ﻿using System.Threading.Tasks;
 using System.Web.Http;
+using GitHubExtension.Infrastructure.Constants;
 
 using GitHubExtension.Notes.WebApi.Commands;
 using GitHubExtension.Notes.WebApi.Constants;
+using GitHubExtension.Notes.WebApi.Extensions;
 using GitHubExtension.Notes.WebApi.Mappers;
 using GitHubExtension.Notes.WebApi.Queries;
 using GitHubExtension.Notes.WebApi.ViewModels;
@@ -10,7 +12,7 @@ using GitHubExtension.Notes.WebApi.ViewModels;
 namespace GitHubExtension.Notes.WebApi.Controllers
 {
     public class NoteController : ApiController
-    {
+    { 
         private readonly INoteCommands _commands;
 
         private readonly INoteQueries _queries;
@@ -21,7 +23,28 @@ namespace GitHubExtension.Notes.WebApi.Controllers
             _queries = queries;
         }
 
-        [Route(NotesRouteConstants.CreateNoteRoute)]
+        [Route(RouteConstants.GetNoteForCollaborator)]
+        [HttpGet]
+        public IHttpActionResult GetNote([FromUri] string collaboratorId)
+        {
+            var userId = User.GetUserId();
+            if (userId == null)
+            {
+                ModelState.AddModelError(ValidationConstants.UserId, ValidationConstants.UserIdError);
+                return BadRequest(ModelState);
+            }
+
+            var note = _queries.GetNote(userId, collaboratorId);
+            if (note == null)
+            {
+                return NotFound();
+            }
+
+            var noteModel = note.ToNoteViewModel();
+            return Ok(noteModel);
+        }
+
+        [Route(RouteConstants.CreateNoteForCollaborator)]
         [HttpPost]
         public async Task<IHttpActionResult> CreateNote(AddNoteModel model)
         {
@@ -42,21 +65,6 @@ namespace GitHubExtension.Notes.WebApi.Controllers
             var noteEntity = noteModel.ToEntity();
             await _commands.AddNote(noteEntity);
             return Ok(noteEntity);
-        }
-
-        [Route(NotesRouteConstants.GetNoteRoute)]
-        [HttpGet]
-        public async Task<IHttpActionResult> GetNote([FromUri] string collaboratorId)
-        {
-            var userId = User.GetUserId();
-            var note = await _queries.GetNote(userId, collaboratorId);
-            if (note == null)
-            {
-                return NotFound();
-            }
-
-            var noteModel = note.ToNoteViewModel();
-            return Ok(noteModel);
         }
     }
 }

--- a/DevelopGitHub/GitHubExtension/GitHubExtension.Notes.WebApi/Extensions/IdentityExtensions.cs
+++ b/DevelopGitHub/GitHubExtension/GitHubExtension.Notes.WebApi/Extensions/IdentityExtensions.cs
@@ -3,7 +3,7 @@ using System.Security.Principal;
 
 using Microsoft.AspNet.Identity;
 
-namespace GitHubExtension.Notes.WebApi
+namespace GitHubExtension.Notes.WebApi.Extensions
 {
     public static class IdentityExtensions
     {

--- a/DevelopGitHub/GitHubExtension/GitHubExtension.Notes.WebApi/Extensions/NoteQueriesExtensions.cs
+++ b/DevelopGitHub/GitHubExtension/GitHubExtension.Notes.WebApi/Extensions/NoteQueriesExtensions.cs
@@ -1,0 +1,17 @@
+﻿using System.Data.Entity;
+using System.Linq;
+using GitHubExtension.Notes.DAL.Model;
+using GitHubExtension.Notes.WebApi.Queries;
+
+namespace GitHubExtension.Notes.WebApi.Extensions
+{
+    public static class NoteQueriesExtensions
+    {
+        public static Note GetNote(this INoteQueries noteQuery, string userId, string collaboratorId)
+        {
+            var note = noteQuery.Notes.AsNoTracking()
+                .FirstOrDefault(n => n.UserId == userId && n.CollaboratorId == collaboratorId);
+            return note;
+        } 
+    }
+}

--- a/DevelopGitHub/GitHubExtension/GitHubExtension.Notes.WebApi/GitHubExtension.Notes.WebApi.csproj
+++ b/DevelopGitHub/GitHubExtension/GitHubExtension.Notes.WebApi/GitHubExtension.Notes.WebApi.csproj
@@ -100,9 +100,9 @@
   <ItemGroup>
     <Compile Include="Commands\INoteCommands.cs" />
     <Compile Include="Commands\NoteCommands.cs" />
-    <Compile Include="Constants\NotesRouteConstants.cs" />
     <Compile Include="Controllers\NoteController.cs" />
-    <Compile Include="IdentityExtensions.cs" />
+    <Compile Include="Extensions\IdentityExtensions.cs" />
+    <Compile Include="Extensions\NoteQueriesExtensions.cs" />
     <Compile Include="Mappers\NoteMapper.cs" />
     <Compile Include="Package\NotesPackage.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
@@ -115,6 +115,10 @@
   </ItemGroup>
   <ItemGroup />
   <ItemGroup>
+    <ProjectReference Include="..\GitHubExtension.Infrastructure.Constants\GitHubExtension.Infrastructure.Constants.csproj">
+      <Project>{642455c5-0a4b-4e25-a2c3-1f1304a0d7dd}</Project>
+      <Name>GitHubExtension.Infrastructure.Constants</Name>
+    </ProjectReference>
     <ProjectReference Include="..\GitHubExtension.Notes.DAL\GitHubExtension.Notes.DAL.csproj">
       <Project>{72035e1a-fcfd-48f1-81dd-7dbc724dd8e9}</Project>
       <Name>GitHubExtension.Notes.DAL</Name>

--- a/DevelopGitHub/GitHubExtension/GitHubExtension.Notes.WebApi/Queries/INoteQueries.cs
+++ b/DevelopGitHub/GitHubExtension/GitHubExtension.Notes.WebApi/Queries/INoteQueries.cs
@@ -1,11 +1,10 @@
-﻿using System.Threading.Tasks;
-
+﻿using System.Linq;
 using GitHubExtension.Notes.DAL.Model;
 
 namespace GitHubExtension.Notes.WebApi.Queries
 {
     public interface INoteQueries
     {
-        Task<Note> GetNote(string userId, string collaboratorId);
+        IOrderedQueryable<Note> Notes { get; }
     }
 }

--- a/DevelopGitHub/GitHubExtension/GitHubExtension.Notes.WebApi/Queries/NoteQueries.cs
+++ b/DevelopGitHub/GitHubExtension/GitHubExtension.Notes.WebApi/Queries/NoteQueries.cs
@@ -14,7 +14,7 @@ namespace GitHubExtension.Notes.WebApi.Queries
 
         public IOrderedQueryable<Note> Notes
         {
-            get {return _notesContext.Notes;}
+            get { return _notesContext.Notes; }
         }
     }
 }

--- a/DevelopGitHub/GitHubExtension/GitHubExtension.Notes.WebApi/Queries/NoteQueries.cs
+++ b/DevelopGitHub/GitHubExtension/GitHubExtension.Notes.WebApi/Queries/NoteQueries.cs
@@ -1,6 +1,4 @@
-﻿using System.Data.Entity;
-using System.Threading.Tasks;
-
+﻿using System.Linq;
 using GitHubExtension.Notes.DAL.Model;
 
 namespace GitHubExtension.Notes.WebApi.Queries
@@ -14,12 +12,9 @@ namespace GitHubExtension.Notes.WebApi.Queries
             _notesContext = notesContext;
         }
 
-        public async Task<Note> GetNote(string userId, string collaboratorId)
+        public IOrderedQueryable<Note> Notes
         {
-            var note =
-                await
-                _notesContext.Notes.FirstOrDefaultAsync(x => x.UserId == userId && x.CollaboratorId == collaboratorId);
-            return note;
+            get {return _notesContext.Notes;}
         }
     }
 }

--- a/DevelopGitHub/GitHubExtension/GitHubExtension.sln
+++ b/DevelopGitHub/GitHubExtension/GitHubExtension.sln
@@ -49,7 +49,13 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Statistics", "Statistics", 
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "GitHubExtension.Statistics.WebApi", "GitHubExtension.Statistics.WebApi\GitHubExtension.Statistics.WebApi.csproj", "{AC64CE56-A38A-4866-82F5-A3BE35EF2EA8}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "GitHubExtension.Notes.Tests", "GitHubExtension.Notes.Tests\GitHubExtension.Notes.Tests.csproj", "{FEF89135-5ECD-4D37-B19D-F6D3685411CA}"
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "GitHubExtension.Activity.Internal.Tests", "GitHubExtension.Activity.Internal.Tests\GitHubExtension.Activity.Internal.Tests.csproj", "{07C98A3E-352E-4DB6-B9E1-FE67080EA388}"
+EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = ".nuget", ".nuget", "{88991CFC-C91B-4E6F-9CCB-489BC3ADE65F}"
+	ProjectSection(SolutionItems) = preProject
+		.nuget\packages.config = .nuget\packages.config
+	EndProjectSection
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -115,6 +121,10 @@ Global
 		{AC64CE56-A38A-4866-82F5-A3BE35EF2EA8}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{AC64CE56-A38A-4866-82F5-A3BE35EF2EA8}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{AC64CE56-A38A-4866-82F5-A3BE35EF2EA8}.Release|Any CPU.Build.0 = Release|Any CPU
+		{FEF89135-5ECD-4D37-B19D-F6D3685411CA}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{FEF89135-5ECD-4D37-B19D-F6D3685411CA}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{FEF89135-5ECD-4D37-B19D-F6D3685411CA}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{FEF89135-5ECD-4D37-B19D-F6D3685411CA}.Release|Any CPU.Build.0 = Release|Any CPU
 		{07C98A3E-352E-4DB6-B9E1-FE67080EA388}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{07C98A3E-352E-4DB6-B9E1-FE67080EA388}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{07C98A3E-352E-4DB6-B9E1-FE67080EA388}.Release|Any CPU.ActiveCfg = Release|Any CPU
@@ -138,6 +148,7 @@ Global
 		{73A2445E-6FC0-4B75-A26B-1F27070AFDBA} = {679070DC-AD4C-4D15-818C-BB9373C306EA}
 		{642455C5-0A4B-4E25-A2C3-1F1304A0D7DD} = {209E6B92-CFA7-42C1-A7D6-2BD7CB0CDD12}
 		{AC64CE56-A38A-4866-82F5-A3BE35EF2EA8} = {EB58C9DD-5C62-4F43-9C22-833830D82B9F}
+		{FEF89135-5ECD-4D37-B19D-F6D3685411CA} = {81F8C705-AC42-4E92-8877-606314287DC0}
 		{07C98A3E-352E-4DB6-B9E1-FE67080EA388} = {81F8C705-AC42-4E92-8877-606314287DC0}
 	EndGlobalSection
 EndGlobal


### PR DESCRIPTION
Added Tests for CreateNote, GetNote methods
Added Tests for Validator and Routes
Changed NoteQueries to work with IOrderedQueryable
<a href='#crh-start'></a><a href='#crh-data-%7B%22processed%22%3A%20%5B%22https%3A//github.com/ITsvetkoFF/Kv-013/pull/96%23discussion_r61047401%22%2C%20%22https%3A//github.com/ITsvetkoFF/Kv-013/pull/96%23discussion_r61047574%22%2C%20%22https%3A//github.com/ITsvetkoFF/Kv-013/pull/96%23discussion_r61048153%22%2C%20%22https%3A//github.com/ITsvetkoFF/Kv-013/pull/96%23discussion_r61112582%22%2C%20%22https%3A//github.com/ITsvetkoFF/Kv-013/pull/96%23discussion_r61112729%22%2C%20%22https%3A//github.com/ITsvetkoFF/Kv-013/pull/96%23discussion_r61113769%22%2C%20%22https%3A//github.com/ITsvetkoFF/Kv-013/pull/96%23discussion_r61212156%22%2C%20%22https%3A//github.com/ITsvetkoFF/Kv-013/pull/96%23discussion_r61212309%22%2C%20%22https%3A//github.com/ITsvetkoFF/Kv-013/pull/96%23discussion_r61214285%22%2C%20%22https%3A//github.com/ITsvetkoFF/Kv-013/pull/96%23discussion_r61214288%22%2C%20%22https%3A//github.com/ITsvetkoFF/Kv-013/pull/96%23discussion_r61382395%22%5D%2C%20%22comments%22%3A%20%7B%22Pull%207bd825394ab24e7182eefe955df7a45d2a730602%20DevelopGitHub/GitHubExtension/GitHubExtension.Notes.Tests/TestsForRoutes/NoteRouteTests.cs%2021%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/ITsvetkoFF/Kv-013/pull/96%23discussion_r61048153%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22Can%20you%20prevent%20code%20duplication%3F%22%2C%20%22created_at%22%3A%20%222016-04-26T08%3A41%3A53Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6068068%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/TerraVenil%22%7D%7D%2C%20%7B%22body%22%3A%20%22I%20managed%20to%20work%20correctly%20with%20routes%20from%20attributes%20only%20by%20calling%20GetRoutes%20method%20each%20time%20when%20url%20for%20a%20specific%20route%20is%20set%20and%20now%20I%20have%20to%20call%20it%20for%20each%20test.%20%20%20%22%2C%20%22created_at%22%3A%20%222016-04-26T16%3A03%3A04Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/14029898%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/Rudeka%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20DevelopGitHub/GitHubExtension/GitHubExtension.Notes.Tests/TestsForRoutes/NoteRouteTests.cs%3AL1-34%22%7D%2C%20%22Pull%207bd825394ab24e7182eefe955df7a45d2a730602%20DevelopGitHub/GitHubExtension/GitHubExtension.Notes.Tests/Extensions/IdentityExtensions.cs%2012%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/ITsvetkoFF/Kv-013/pull/96%23discussion_r61047401%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22You%20really%20need%20substitute%20for%20GenericIdentity%3F%22%2C%20%22created_at%22%3A%20%222016-04-26T08%3A36%3A37Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6068068%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/TerraVenil%22%7D%7D%2C%20%7B%22body%22%3A%20%22Changed%20to%20new%20instance%20instead%20of%20mock%20and%20commited%22%2C%20%22created_at%22%3A%20%222016-04-26T15%3A56%3A40Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/14029898%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/Rudeka%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20DevelopGitHub/GitHubExtension/GitHubExtension.Notes.Tests/Extensions/IdentityExtensions.cs%3AL1-19%22%7D%2C%20%22Pull%20ad959c8a6c32e47f136eaae86602a08545612547%20DevelopGitHub/GitHubExtension/GitHubExtension.Notes.Tests/Extensions/IdentityExtensions.cs%209%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/ITsvetkoFF/Kv-013/pull/96%23discussion_r61212156%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22Please%20prevent%20code%20duplication%20code%20after%20rebase.%22%2C%20%22created_at%22%3A%20%222016-04-27T06%3A58%3A57Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6068068%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/TerraVenil%22%7D%7D%2C%20%7B%22body%22%3A%20%22I%20have%20renamed%20the%20class%20to%20TestsIdentityExtensions%20and%20commited%22%2C%20%22created_at%22%3A%20%222016-04-27T07%3A23%3A11Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/14029898%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/Rudeka%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20DevelopGitHub/GitHubExtension/GitHubExtension.Notes.Tests/Extensions/IdentityExtensions.cs%3AL1-18%22%7D%2C%20%22Pull%207bd825394ab24e7182eefe955df7a45d2a730602%20DevelopGitHub/GitHubExtension/GitHubExtension.Notes.Tests/TestsForControllers/NoteControllerCreateNoteTests.cs%2024%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/ITsvetkoFF/Kv-013/pull/96%23discussion_r61047574%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22Data%20for%20what%20model%3F%22%2C%20%22created_at%22%3A%20%222016-04-26T08%3A37%3A33Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6068068%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/TerraVenil%22%7D%7D%2C%20%7B%22body%22%3A%20%22Changed%20to%20a%20more%20explicit%20name%20and%20commited%22%2C%20%22created_at%22%3A%20%222016-04-26T15%3A57%3A27Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/14029898%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/Rudeka%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20DevelopGitHub/GitHubExtension/GitHubExtension.Notes.Tests/TestsForControllers/NoteControllerCreateNoteTests.cs%3AL1-106%22%7D%2C%20%22Pull%20ad959c8a6c32e47f136eaae86602a08545612547%20DevelopGitHub/GitHubExtension/GitHubExtension.Notes.Tests/TestsForValidator/NoteValidatorTests.cs%2010%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/ITsvetkoFF/Kv-013/pull/96%23discussion_r61212309%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22Where%20the%20positive%20test%3F%22%2C%20%22created_at%22%3A%20%222016-04-27T07%3A00%3A52Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6068068%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/TerraVenil%22%7D%7D%2C%20%7B%22body%22%3A%20%22There%20are%20positive%20tests%20below%20e.g.%20ShouldNotHaveErrorWhenBodyIsSpecified.%20I%20think%20it%20is%20better%20to%20rename%20it%20something%20like%20ValidModelWhenBodyIsSpecified.%20Made%20changes%20and%20commited.%22%2C%20%22created_at%22%3A%20%222016-04-27T07%3A23%3A12Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/14029898%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/Rudeka%22%7D%7D%2C%20%7B%22body%22%3A%20%22Good%20idea%21%22%2C%20%22created_at%22%3A%20%222016-04-28T07%3A16%3A28Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6068068%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/TerraVenil%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20DevelopGitHub/GitHubExtension/GitHubExtension.Notes.Tests/TestsForValidator/NoteValidatorTests.cs%3AL1-38%22%7D%7D%7D'></a>
<a href='https://www.codereviewhub.com/'><img src='http://www.codereviewhub.com/site/github-bar.png' height=40></a>
- [ ] <a href='#crh-comment-Pull 7bd825394ab24e7182eefe955df7a45d2a730602 DevelopGitHub/GitHubExtension/GitHubExtension.Notes.Tests/Extensions/IdentityExtensions.cs 12'></a> <img src='http://www.codereviewhub.com/site/github-remaining.png' height=16 width=60>&nbsp;<b><a href='https://github.com/ITsvetkoFF/Kv-013/pull/96#discussion_r61047401'>File: DevelopGitHub/GitHubExtension/GitHubExtension.Notes.Tests/Extensions/IdentityExtensions.cs:L1-19</a></b>
- <a href='https://github.com/TerraVenil'><img border=0 src='https://avatars.githubusercontent.com/u/6068068?v=3' height=16 width=16'></a> You really need substitute for GenericIdentity?
- <a href='https://github.com/Rudeka'><img border=0 src='https://avatars.githubusercontent.com/u/14029898?v=3' height=16 width=16'></a> Changed to new instance instead of mock and commited
- [ ] <a href='#crh-comment-Pull 7bd825394ab24e7182eefe955df7a45d2a730602 DevelopGitHub/GitHubExtension/GitHubExtension.Notes.Tests/TestsForControllers/NoteControllerCreateNoteTests.cs 24'></a> <img src='http://www.codereviewhub.com/site/github-remaining.png' height=16 width=60>&nbsp;<b><a href='https://github.com/ITsvetkoFF/Kv-013/pull/96#discussion_r61047574'>File: DevelopGitHub/GitHubExtension/GitHubExtension.Notes.Tests/TestsForControllers/NoteControllerCreateNoteTests.cs:L1-106</a></b>
- <a href='https://github.com/TerraVenil'><img border=0 src='https://avatars.githubusercontent.com/u/6068068?v=3' height=16 width=16'></a> Data for what model?
- <a href='https://github.com/Rudeka'><img border=0 src='https://avatars.githubusercontent.com/u/14029898?v=3' height=16 width=16'></a> Changed to a more explicit name and commited
- [ ] <a href='#crh-comment-Pull 7bd825394ab24e7182eefe955df7a45d2a730602 DevelopGitHub/GitHubExtension/GitHubExtension.Notes.Tests/TestsForRoutes/NoteRouteTests.cs 21'></a> <img src='http://www.codereviewhub.com/site/github-remaining.png' height=16 width=60>&nbsp;<b><a href='https://github.com/ITsvetkoFF/Kv-013/pull/96#discussion_r61048153'>File: DevelopGitHub/GitHubExtension/GitHubExtension.Notes.Tests/TestsForRoutes/NoteRouteTests.cs:L1-34</a></b>
- <a href='https://github.com/TerraVenil'><img border=0 src='https://avatars.githubusercontent.com/u/6068068?v=3' height=16 width=16'></a> Can you prevent code duplication?
- <a href='https://github.com/Rudeka'><img border=0 src='https://avatars.githubusercontent.com/u/14029898?v=3' height=16 width=16'></a> I managed to work correctly with routes from attributes only by calling GetRoutes method each time when url for a specific route is set and now I have to call it for each test.
- [ ] <a href='#crh-comment-Pull ad959c8a6c32e47f136eaae86602a08545612547 DevelopGitHub/GitHubExtension/GitHubExtension.Notes.Tests/Extensions/IdentityExtensions.cs 9'></a> <img src='http://www.codereviewhub.com/site/github-remaining.png' height=16 width=60>&nbsp;<b><a href='https://github.com/ITsvetkoFF/Kv-013/pull/96#discussion_r61212156'>File: DevelopGitHub/GitHubExtension/GitHubExtension.Notes.Tests/Extensions/IdentityExtensions.cs:L1-18</a></b>
- <a href='https://github.com/TerraVenil'><img border=0 src='https://avatars.githubusercontent.com/u/6068068?v=3' height=16 width=16'></a> Please prevent code duplication code after rebase.
- <a href='https://github.com/Rudeka'><img border=0 src='https://avatars.githubusercontent.com/u/14029898?v=3' height=16 width=16'></a> I have renamed the class to TestsIdentityExtensions and commited
- [ ] <a href='#crh-comment-Pull ad959c8a6c32e47f136eaae86602a08545612547 DevelopGitHub/GitHubExtension/GitHubExtension.Notes.Tests/TestsForValidator/NoteValidatorTests.cs 10'></a> <img src='http://www.codereviewhub.com/site/github-remaining.png' height=16 width=60>&nbsp;<b><a href='https://github.com/ITsvetkoFF/Kv-013/pull/96#discussion_r61212309'>File: DevelopGitHub/GitHubExtension/GitHubExtension.Notes.Tests/TestsForValidator/NoteValidatorTests.cs:L1-38</a></b>
- <a href='https://github.com/TerraVenil'><img border=0 src='https://avatars.githubusercontent.com/u/6068068?v=3' height=16 width=16'></a> Where the positive test?
- <a href='https://github.com/Rudeka'><img border=0 src='https://avatars.githubusercontent.com/u/14029898?v=3' height=16 width=16'></a> There are positive tests below e.g. ShouldNotHaveErrorWhenBodyIsSpecified. I think it is better to rename it something like ValidModelWhenBodyIsSpecified. Made changes and commited.
- <a href='https://github.com/TerraVenil'><img border=0 src='https://avatars.githubusercontent.com/u/6068068?v=3' height=16 width=16'></a> Good idea!

<a href='https://www.codereviewhub.com/ITsvetkoFF/Kv-013/pull/96?mark_as_completed=1'><img src='http://www.codereviewhub.com/site/github-mark-as-completed.png' height=26></a>&nbsp;<a href='https://www.codereviewhub.com/ITsvetkoFF/Kv-013/pull/96?approve=1'><img src='http://www.codereviewhub.com/site/github-approve.png' height=26></a>&nbsp;<a href='https://github.com/ITsvetkoFF/Kv-013/pull/96'><img src='http://www.codereviewhub.com/site/github-refresh.png' height=26></a>
<a href='#crh-end'></a>
