### PR TITLE
Fix test for assign role to user with wrong data

### DIFF
--- a/DevelopGitHub/GitHubExtension/GitHubExtension.Security.Tests/TestForControllers/RepositoryControllerAssignRolesToUserTests.cs
+++ b/DevelopGitHub/GitHubExtension/GitHubExtension.Security.Tests/TestForControllers/RepositoryControllerAssignRolesToUserTests.cs
@@ -7,6 +7,7 @@ using System.Web.Http.Results;
 
 using FluentAssertions;
 
+using GitHubExtension.Infrastructure.Constants;
 using GitHubExtension.Security.DAL.Context;
 using GitHubExtension.Security.DAL.Identity;
 using GitHubExtension.Security.DAL.Infrastructure;
@@ -27,7 +28,7 @@ namespace GitHubExtension.Security.Tests.TestForControllers
 {
     public class RepositoryControllerAssignRolesToUserTests
     {
-        private const string ExpectedErrorForInvalidRole = "Roles '{0}' does not exists in the system";
+        private const string ExpectedErrorForInvalidRole = RoleValidationConstants.RoleNotExist;
 
         private const string RoleIndex = "role";
 


### PR DESCRIPTION
<a href='#crh-start'></a><a href='#crh-data-%7B%7D'></a>
<a href='https://www.codereviewhub.com/'><img src='http://www.codereviewhub.com/site/github-bar.png' height=40></a>
<a href='https://www.codereviewhub.com/ITsvetkoFF/Kv-013/pull/123?approve=1'><img src='http://www.codereviewhub.com/site/github-approve.png' height=26></a>&nbsp;<a href='https://github.com/ITsvetkoFF/Kv-013/pull/123'><img src='http://www.codereviewhub.com/site/github-refresh.png' height=26></a>
<a href='#crh-end'></a>
